### PR TITLE
Make address of service configurable

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,7 +34,6 @@ func init() {
 }
 
 func main() {
-
 	flag.Parse()
 	log.Println("Integrations registry started.")
 	defer log.Println("Integrations registry stopped.")

--- a/main.go
+++ b/main.go
@@ -24,15 +24,18 @@ import (
 
 var (
 	packagesPath string
+	address      string
 	version      = "0.0.1"
 )
 
 func init() {
-	packagesPath = *flag.String("packages-path", "./packages", "Path to integration packages directory.")
+	flag.StringVar(&packagesPath, "packages-path", "./packages", "Path to integration packages directory.")
+	flag.StringVar(&address, "address", "localhost:8080", "Address of the integrations-registry service.")
 }
 
 func main() {
 
+	flag.Parse()
 	log.Println("Integrations registry started.")
 	defer log.Println("Integrations registry stopped.")
 
@@ -44,7 +47,7 @@ func main() {
 	router.HandleFunc("/package/{name}/get", downloadHandler)
 	router.HandleFunc("/img/{name}.png", imgHandler)
 
-	log.Fatal(http.ListenAndServe("localhost:8080", router))
+	log.Fatal(http.ListenAndServe(address, router))
 }
 
 func downloadHandler(w http.ResponseWriter, r *http.Request) {

--- a/main.go
+++ b/main.go
@@ -229,7 +229,6 @@ func readManifest(p string) (*Manifest, error) {
 }
 
 func readIcon(p string) ([]byte, error) {
-
 	r, err := zip.OpenReader(packagesPath + "/" + p + ".zip")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Before the service was always exposed on `localhost:8080`. This default stays but with this change it is possible to also specify a different address / port:

```
 go run main.go -address="localhost:8081"
```