### PR TITLE
Introduce package struct to align API calls output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ WORKDIR "/go/src/github.com/elastic/integrations-registry"
 RUN GO111MODULE=on go mod vendor
 
 # Make sure it's accessible from outside the container
-CMD ["go", "run", "main.go", "--address=0.0.0.0:8080"]
+ENTRYPOINT ["go", "run", ".", "--address=0.0.0.0:8080"]

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ A full example with the directory structure looks as following:
 There are two options to run this. Either the service can be run as a go command or inside a docker container.
 
 ### Go command
-`go run main.go`
+`go run .`
 
 ### Docker
 **General**

--- a/docs/api/package.json
+++ b/docs/api/package.json
@@ -2,6 +2,7 @@
   "name": "envoyproxy",
   "version": "0.0.5",
   "description": "This is the envoyproxy integration with improved features.",
+  "icon": "/img/envoyproxy-0.0.5/icon.png",
   "requirement": {
     "kibana": {
       "min": "",

--- a/handler.go
+++ b/handler.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/gorilla/mux"
+)
+
+func downloadHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	file := vars["name"]
+
+	path := packagesPath + "/" + file + ".zip"
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		log.Println(err)
+		http.NotFound(w, r)
+		return
+	}
+
+	d, err := ioutil.ReadFile(path)
+	if err != nil {
+		log.Println(err)
+		http.NotFound(w, r)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Description", "File Transfer")
+	w.Header().Set("Content-Disposition", "attachment; filename=\""+file+".zip\"")
+	w.Header().Set("Content-Transfer-Encoding", "binary")
+
+	fmt.Fprint(w, string(d))
+}
+
+func infoHandler() func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"version": "%s"}`, version)
+	}
+}
+
+func packageHandler() func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		vars := mux.Vars(r)
+		key := vars["name"]
+
+		manifest, err := readManifest(key)
+		if err != nil {
+			log.Printf("Manifest not found: %s, %s", key, manifest)
+			http.NotFound(w, r)
+			return
+		}
+		// It's not set by default, generate it
+		manifest.Icon = manifest.getIcon()
+
+		data, err := json.MarshalIndent(manifest, "", "  ")
+		if err != nil {
+			log.Fatal(data)
+		}
+
+		fmt.Fprint(w, string(data))
+	}
+}
+
+func imgHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	integration := vars["name"]
+	file := vars["file"]
+
+	img, err := readImage(integration, file)
+	if err != nil {
+		http.Error(w, "integration "+integration+" not found", 404)
+		return
+	}
+
+	// Package exists but does not have an icon, so the default icon is shipped
+	if img == nil {
+		if file == "icon.png" {
+			img, err = ioutil.ReadFile("./img/icon.png")
+			if err != nil {
+				http.NotFound(w, r)
+				return
+			}
+		} else {
+			http.NotFound(w, r)
+			return
+		}
+	}
+
+	// Safety check for too short paths
+	if len(file) < 3 {
+		http.NotFound(w, r)
+		return
+	}
+
+	suffix := file[len(file)-3:]
+
+	// Only .png and .jpg are supported at the moment
+	if suffix == "png" {
+		w.Header().Set("Content-Type", "image/png")
+	} else if suffix == "jpg" {
+		w.Header().Set("Content-Type", "image/jpeg")
+	} else {
+		http.NotFound(w, r)
+		return
+	}
+
+	fmt.Fprint(w, string(img))
+}
+
+func listHandler() func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		integrations, err := getIntegrationPackages()
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+
+		var output []map[string]string
+		for _, i := range integrations {
+			m, err := readManifest(i)
+			if err != nil {
+				http.NotFound(w, r)
+				return
+			}
+
+			data := map[string]string{
+				"name":        m.Name,
+				"description": m.Description,
+				"version":     m.Version,
+				"icon":        m.getIcon(),
+			}
+			output = append(output, data)
+		}
+		j, err := json.MarshalIndent(output, "", "  ")
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, string(j))
+	}
+}

--- a/main.go
+++ b/main.go
@@ -7,14 +7,10 @@ package main
 import (
 	"archive/zip"
 	"bytes"
-	"encoding/json"
 	"flag"
-	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -55,141 +51,6 @@ func getRouter() *mux.Router {
 	return router
 }
 
-func downloadHandler(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-	file := vars["name"]
-
-	path := packagesPath + "/" + file + ".zip"
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		log.Println(err)
-		http.NotFound(w, r)
-		return
-	}
-
-	d, err := ioutil.ReadFile(path)
-	if err != nil {
-		log.Println(err)
-		http.NotFound(w, r)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/octet-stream")
-	w.Header().Set("Content-Description", "File Transfer")
-	w.Header().Set("Content-Disposition", "attachment; filename=\""+file+".zip\"")
-	w.Header().Set("Content-Transfer-Encoding", "binary")
-
-	fmt.Fprint(w, string(d))
-}
-
-func infoHandler() func(w http.ResponseWriter, r *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"version": "%s"}`, version)
-	}
-}
-
-func packageHandler() func(w http.ResponseWriter, r *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		vars := mux.Vars(r)
-		key := vars["name"]
-
-		manifest, err := readManifest(key)
-		if err != nil {
-			log.Printf("Manifest not found: %s, %s", key, manifest)
-			http.NotFound(w, r)
-			return
-		}
-
-		data, err := json.MarshalIndent(manifest, "", "  ")
-		if err != nil {
-			log.Fatal(data)
-		}
-
-		fmt.Fprint(w, string(data))
-	}
-}
-
-func imgHandler(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-	integration := vars["name"]
-	file := vars["file"]
-
-	img, err := readImage(integration, file)
-	if err != nil {
-		http.Error(w, "integration "+integration+" not found", 404)
-		return
-	}
-
-	// Package exists but does not have an icon, so the default icon is shipped
-	if img == nil {
-		if file == "icon.png" {
-			img, err = ioutil.ReadFile("./img/icon.png")
-			if err != nil {
-				http.NotFound(w, r)
-				return
-			}
-		} else {
-			http.NotFound(w, r)
-			return
-		}
-	}
-
-	// Safety check for too short paths
-	if len(file) < 3 {
-		http.NotFound(w, r)
-		return
-	}
-
-	suffix := file[len(file)-3:]
-
-	// Only .png and .jpg are supported at the moment
-	if suffix == "png" {
-		w.Header().Set("Content-Type", "image/png")
-	} else if suffix == "jpg" {
-		w.Header().Set("Content-Type", "image/jpeg")
-	} else {
-		http.NotFound(w, r)
-		return
-	}
-
-	fmt.Fprint(w, string(img))
-}
-
-func listHandler() func(w http.ResponseWriter, r *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
-
-		integrations, err := getIntegrationPackages()
-		if err != nil {
-			http.NotFound(w, r)
-			return
-		}
-
-		var output []map[string]string
-		for _, i := range integrations {
-			m, err := readManifest(i)
-			if err != nil {
-				http.NotFound(w, r)
-				return
-			}
-			data := map[string]string{
-				"name":        m.Name,
-				"description": m.Description,
-				"version":     m.Version,
-				"icon":        "/img/" + m.Name + "-" + m.Version + "/icon.png",
-			}
-			output = append(output, data)
-		}
-		j, err := json.MarshalIndent(output, "", "  ")
-		if err != nil {
-			http.NotFound(w, r)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, string(j))
-	}
-}
-
 // getIntegrationPackages returns list of available integration packages
 func getIntegrationPackages() ([]string, error) {
 	files, err := filepath.Glob(packagesPath + "/*.zip")
@@ -207,10 +68,19 @@ func getIntegrationPackages() ([]string, error) {
 	return integrations, nil
 }
 
-type Manifest struct {
+type Package struct {
 	Name        string `yaml:"name" json:"name"`
 	Version     string `yaml:"version" json:"version"`
 	Description string `yaml:"description" json:"description"`
+	Icon        string `yaml:"icon" json:"icon"`
+}
+
+func (p *Package) getIcon() string {
+	return "/img/" + p.Name + "-" + p.Version + "/icon.png"
+}
+
+type Manifest struct {
+	Package     `yaml:",inline" json:",inline"`
 	Requirement struct {
 		Kibana struct {
 			Min string `yaml:"min" json:"min"`


### PR DESCRIPTION
To make sure the different API calls which expose package information (/list, /package/*) have the same content / naming, the package object is introduced.

The icon path is added to the detail output to have in the detail view all the information which is also on the top level.

Moved handler and to it's own file for better readability. Server now must be started with `go run .` instead of `go run main.go`.