### PR TITLE
Make running as container work by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,6 @@ EXPOSE 8080
 
 WORKDIR "/go/src/github.com/elastic/integrations-registry"
 RUN GO111MODULE=on go mod vendor
-CMD ["go", "run", "main.go"]
+
+# Make sure it's accessible from outside the container
+CMD ["go", "run", "main.go", "--address=0.0.0.0:8080"]


### PR DESCRIPTION
The default address the service is listening on is `localhost:8080`. Because of this when running inside a docker container, it cant be accessed. The Dockerfile is updated to expose it by default.