### PR TITLE
 Proper shutdown

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ func main() {
 
 	ctx := context.TODO()
 	if err := server.Shutdown(ctx); err != nil {
-		ma	log.Print(err)
+		log.Print(err)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
 	}()
 
 	stop := make(chan os.Signal, 1)
-	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM, os.Interrupt)
+	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
 	<-stop
 
 	ctx := context.TODO()


### PR DESCRIPTION
This refactoring initially came from the issue that `Ctrl-C` did not stop the docker container. It turns out to make it work the container needs to be run with `-i -t`, but the refactoring I did I think is still helpful.

To make params work with Docker like `--address`, ENTRYPOINT instead of CMD is now used for the mandatory parts.