### PR TITLE
Only expose most recent integrations version in /list

### DIFF
--- a/docs/api/list.json
+++ b/docs/api/list.json
@@ -1,12 +1,5 @@
 [
   {
-    "description": "This is the example integration.",
-    "download": "/package/example-0.0.5.tar.gz",
-    "icon": "/img/example-0.0.5/icon.png",
-    "name": "example",
-    "version": "0.0.5"
-  },
-  {
     "description": "This is the example integration",
     "download": "/package/example-1.0.0.tar.gz",
     "icon": "/img/example-1.0.0/icon.png",

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/elastic/integrations-registry
 go 1.12
 
 require (
+	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/elastic/go-licenser v0.0.0-20190206105657-ca40ceca0166 // indirect
 	github.com/gorilla/mux v1.7.2
 	github.com/magefile/mage v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
+github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/elastic/go-licenser v0.0.0-20190206105657-ca40ceca0166 h1:2syKAicoF3fQ13K9V3cY4T+ktVTVljiBW23oNA37Geo=
 github.com/elastic/go-licenser v0.0.0-20190206105657-ca40ceca0166/go.mod h1:D8eNQk70FOCVBl3smCGQt/lv7meBeQno2eI1S5apiHQ=
 github.com/gorilla/mux v1.7.2 h1:zoNxOV7WjqXptQOVngLmcSQgXmgk4NMz1HibBchjl/I=


### PR DESCRIPTION
Until now under `/list` all integrations were exposed, meaning also all versions of an integration. For mysql to versions were exposed. With this change, only the most recent version will be exposed. See https://github.com/elastic/integrations-registry/issues/26 for more discussions.