### PR TITLE
Add integration API endpoint to list packages

### DIFF
--- a/main.go
+++ b/main.go
@@ -67,6 +67,7 @@ func getRouter() *mux.Router {
 	router.HandleFunc("/package/{name}.tar.gz", targzDownloadHandler)
 	router.HandleFunc("/package/{name}.zip", zipDownloadHandler)
 	router.HandleFunc("/package/{name}", packageHandler())
+	router.HandleFunc("/integration/{name}", integrationHandler())
 	router.HandleFunc("/img/{name}/{file}", imgHandler)
 
 	return router


### PR DESCRIPTION
Based on the discussion in https://github.com/elastic/integrations-registry/issues/26 it became obvious that there is also API endpoint needed which list all packages for a specific version. This could have been done in the `/list` API endpoint but I did not like this too much as by default only the newest packages are exposed of an integration and then if an integration name is given, all of this integration? This does not seem to be intuitive.

Instead I propose an `/integration/{name}` endpoint which exposes all the package of an integration. The output for `http://localhost:8080/integration/mysql` looks as following:

```
{
  "integration": "mysql",
  "packages": [
    {
      "name": "mysql",
      "version": "1.0.1",
      "description": "Mysql Logs and metrics",
      "icon": "/img/mysql-1.0.1/icon.png",
      "requirement": {
        "kibana": {
          "min": "",
          "max": ""
        }
      }
    },
    {
      "name": "mysql",
      "version": "1.0.2",
      "description": "Mysql Logs and metrics",
      "icon": "/img/mysql-1.0.2/icon.png",
      "requirement": {
        "kibana": {
          "min": "",
          "max": ""
        }
      }
    }
  ]
}
```

If wonder if long term there could also be additional info around an integration inside here? Or should the description of the integration be taken from the most recent integration?