### PR TITLE
Simplify JSON header handling to be reusable

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -13,7 +13,6 @@ import (
 	"os"
 
 	"github.com/blang/semver"
-
 	"github.com/gorilla/mux"
 )
 
@@ -67,14 +66,13 @@ func targzDownloadHandler(w http.ResponseWriter, r *http.Request) {
 
 func infoHandler() func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
+		jsonHeader(w)
 		fmt.Fprintf(w, `{"version": "%s"}`, version)
 	}
 }
 
 func packageHandler() func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
 		vars := mux.Vars(r)
 		key := vars["name"]
 
@@ -91,6 +89,7 @@ func packageHandler() func(w http.ResponseWriter, r *http.Request) {
 			log.Fatal(data)
 		}
 
+		jsonHeader(w)
 		fmt.Fprint(w, string(data))
 	}
 }
@@ -192,7 +191,7 @@ func listHandler() func(w http.ResponseWriter, r *http.Request) {
 			notFound(w, err)
 			return
 		}
-		w.Header().Set("Content-Type", "application/json")
+		jsonHeader(w)
 		fmt.Fprint(w, string(j))
 	}
 }
@@ -203,4 +202,8 @@ func notFound(w http.ResponseWriter, err error) {
 		errString = err.Error()
 	}
 	http.Error(w, errString, http.StatusNotFound)
+}
+
+func jsonHeader(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
 }

--- a/main.go
+++ b/main.go
@@ -38,9 +38,7 @@ func main() {
 	log.Println("Integrations registry started.")
 	defer log.Println("Integrations registry stopped.")
 
-	router := getRouter()
-
-	server := &http.Server{Addr: address, Handler: router}
+	server := &http.Server{Addr: address, Handler: getRouter()}
 
 	go func() {
 		err := server.ListenAndServe()


### PR DESCRIPTION
In case we ever want to add additional info to the JSON header we can in one place. This also prevents copy / paste mistakes for header details.