### PR TITLE
Add download stats

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,1 +1,3 @@
 packages.path: "./build/packages"
+
+stats.elasticsearch: ["http://localhost:9200"]

--- a/dev/stats/mapping.json
+++ b/dev/stats/mapping.json
@@ -1,0 +1,23 @@
+{
+  "aliases": {},
+  "mappings": {
+    "properties": {
+      "@timestamp": {
+        "type": "date"
+      },
+      "package": {
+        "type": "keyword"
+      },
+      "source": {
+        "properties": {
+          "ip": {
+            "type": "ip"
+          }
+        }
+      },
+      "version": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/blang/semver v3.5.1+incompatible // indirect
+	github.com/elastic/go-elasticsearch v0.0.0 // indirect
 	github.com/elastic/go-licenser v0.0.0-20190206105657-ca40ceca0166 // indirect
 	github.com/elastic/go-ucfg v0.7.0 // indirect
 	github.com/gorilla/mux v1.7.2

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/elastic/go-elasticsearch v0.0.0 h1:Pd5fqOuBxKxv83b0+xOAJDAkziWYwFinWnBO0y+TZaA=
+github.com/elastic/go-elasticsearch v0.0.0/go.mod h1:TkBSJBuTyFdBnrNqoPc54FN0vKf5c04IdM4zuStJ7xg=
 github.com/elastic/go-licenser v0.0.0-20190206105657-ca40ceca0166 h1:2syKAicoF3fQ13K9V3cY4T+ktVTVljiBW23oNA37Geo=
 github.com/elastic/go-licenser v0.0.0-20190206105657-ca40ceca0166/go.mod h1:D8eNQk70FOCVBl3smCGQt/lv7meBeQno2eI1S5apiHQ=
 github.com/elastic/go-ucfg v0.7.0 h1:1+C/sZdJKww8hKl7XtLPTjs4cFslhQF2fazKTF+ZE+4=

--- a/handler.go
+++ b/handler.go
@@ -72,6 +72,7 @@ func targzDownloadHandler(w http.ResponseWriter, r *http.Request) {
 
 	fmt.Fprint(w, string(d))
 
+	// TODO: do this async to not block the request
 	logDownload(r, file)
 }
 
@@ -87,6 +88,8 @@ func logDownload(r *http.Request, file string) {
 
 	log.Print(data)
 
+	// TODO: only create an instance if statsAddresses > 0
+	// Should we even create it each time or not?
 	esConfig := elasticsearch.Config{
 		Addresses: statsAddresses,
 	}

--- a/handler.go
+++ b/handler.go
@@ -15,11 +15,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/elastic/go-elasticsearch/esapi"
-
-	"github.com/elastic/go-elasticsearch"
-
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/go-elasticsearch"
+	"github.com/elastic/go-elasticsearch/esapi"
 
 	"github.com/blang/semver"
 	"github.com/gorilla/mux"
@@ -89,7 +87,10 @@ func logDownload(r *http.Request, file string) {
 
 	log.Print(data)
 
-	es, err := elasticsearch.NewDefaultClient()
+	esConfig := elasticsearch.Config{
+		Addresses: statsAddresses,
+	}
+	es, err := elasticsearch.NewClient(esConfig)
 	if err != nil {
 		log.Fatalf("Error creating the client: %s", err)
 	}
@@ -106,6 +107,11 @@ func logDownload(r *http.Request, file string) {
 		log.Fatalf("Error getting response: %s", err)
 	}
 	defer res.Body.Close()
+
+	/*body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		log.Fatalf("Error reading body: %s", err)
+	}*/
 }
 
 func infoHandler() func(w http.ResponseWriter, r *http.Request) {

--- a/main.go
+++ b/main.go
@@ -25,10 +25,11 @@ import (
 )
 
 var (
-	packagesPath string
-	address      string
-	version      = "0.0.1"
-	configPath   = "config.yml"
+	packagesPath   string
+	address        string
+	statsAddresses []string
+	version        = "0.0.1"
+	configPath     = "config.yml"
 )
 
 func init() {
@@ -36,7 +37,8 @@ func init() {
 }
 
 type Config struct {
-	PackagesPath string `config:"packages.path"`
+	PackagesPath   string   `config:"packages.path"`
+	StatsAddresses []string `config:"stats.elasticsearch"`
 }
 
 func main() {


### PR DESCRIPTION
Implements a first version of https://github.com/elastic/integrations-registry/issues/31. For now it is logged to the stdout by default and if configured and enabled, also to Elasticsearch.

The mapping for the Elasticsearch index is added under `/dev/stats`. It has to be loaded manually into Elasticsearch.

TODO:

* [ ] Implement config option to enable / disable sending data to Elasticsearch cluster and configuring cluster.