### PR TITLE
Rename /list endpoint to /search

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Endpoints:
 
 * `/`: Info about the registry
-* `/list`: Lis of all available integration packages
+* `/search`: Search for packages. By default returns all the most recent packages available.
 * `/package/{name}`: Info about a package
 * `/package/{name}.tar.gz`: Download a package
 

--- a/handler.go
+++ b/handler.go
@@ -140,7 +140,7 @@ func imgHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, string(img))
 }
 
-func listHandler() func(w http.ResponseWriter, r *http.Request) {
+func searchHandler() func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 
 		integrations, err := getIntegrationPackages()

--- a/main.go
+++ b/main.go
@@ -132,7 +132,7 @@ func getRouter() *mux.Router {
 	router := mux.NewRouter().StrictSlash(true)
 
 	router.HandleFunc("/", infoHandler())
-	router.HandleFunc("/list", listHandler())
+	router.HandleFunc("/search", searchHandler())
 	router.HandleFunc("/package/{name}.tar.gz", targzDownloadHandler)
 	router.HandleFunc("/package/{name}.zip", zipDownloadHandler)
 	router.HandleFunc("/package/{name}", packageHandler())

--- a/main_test.go
+++ b/main_test.go
@@ -31,9 +31,9 @@ func TestEndpoints(t *testing.T) {
 		handler  func(w http.ResponseWriter, r *http.Request)
 	}{
 		{"/", "/", "info.json", infoHandler()},
-		{"/list", "/list", "list.json", listHandler()},
-		{"/list?kibana=6.5.2", "/list", "list-kibana652.json", listHandler()},
-		{"/list?kibana=7.2.1", "/list", "list-kibana721.json", listHandler()},
+		{"/search", "/search", "list.json", searchHandler()},
+		{"/search?kibana=6.5.2", "/search", "list-kibana652.json", searchHandler()},
+		{"/search?kibana=7.2.1", "/search", "list-kibana721.json", searchHandler()},
 		{"/package/example-1.0.0", "/package/{name}", "package.json", packageHandler()},
 	}
 


### PR DESCRIPTION
In recent discussions it became more obvious to me that our current `/list` endpoint is more a search endpoint for packages. It returns a list of packages based on the search query params. At the moment these queries are versions of the different services but long term it could also be a text search. By default the endpoint returns the list of all packages with the most recent version.

This is a breaking change!