### PR TITLE
Add title to more integrations

### DIFF
--- a/dev/main.go
+++ b/dev/main.go
@@ -21,7 +21,7 @@ var packagesPath = "../build/packages/"
 
 type Package struct {
 	Name        string `yaml:"name"`
-	Title        string `yaml:"title"`
+	Title       string `yaml:"title,omitempty"`
 	Version     string `yaml:"version"`
 	Description string `yaml:"description"`
 }

--- a/dev/package-template/manifest.yml
+++ b/dev/package-template/manifest.yml
@@ -1,6 +1,8 @@
 name: {{.Name}}
 description: {{.Description}}
+{{if .Title}}
 title: {{.Title}}
+{{end}}
 version: {{.Version}}
 categories: ["logs", "metrics"]
 release: beta

--- a/dev/packages.yml
+++ b/dev/packages.yml
@@ -1,14 +1,17 @@
 - name: apache
   version: 1.0.1
   description: Apache logs and metrics
+  title: Apache
 - name: docker
   version: 1.2.3
   description: Docker Logs and metrics
+  title: Docker
 - name: elasticsearch
   version: 1.3.1
   description: Elasticsearch Logs and metrics
+  title: Elasticsearch
 - name: haproxy
-  title: HA Proxy
+  title: HAProxy
   version: 1.3.1
   description: HaProxy Logs and metrics
 - name: kafka
@@ -20,18 +23,22 @@
 - name: mongodb
   version: 1.0.1
   description: MongoDB Logs and metrics
+  title: MongoDB
 - name: mysql
   version: 1.0.1
   description: Mysql Logs and metrics
 - name: mysql
   version: 1.0.2
   description: Mysql Logs and metrics
+  title: MySQL
 - name: postgresql
   version: 1.0.2
   description: Postgres SQL Logs and metrics
+  title: PostgreSQL
 - name: rabbitmq
   version: 1.0.2
   description: RabbitMQ Logs and metrics
+  title: RabbitMQ
 - name: system
   version: 2.0.1
   description: System SQL Logs and metrics

--- a/main.go
+++ b/main.go
@@ -162,7 +162,7 @@ func getIntegrationPackages() ([]string, error) {
 
 type Package struct {
 	Name        string  `yaml:"name" json:"name"`
-	Title       *string `yaml:"title" json:"title"`
+	Title       *string `yaml:"title,omitempty" json:"title,omitempty"`
 	Version     string  `yaml:"version" json:"version"`
 	Description string  `yaml:"description" json:"description"`
 	Icon        string  `yaml:"icon" json:"icon"`


### PR DESCRIPTION
This fixes `title: null` in the generated integrations and adds title to some more of the integrations. Some of the integrations do not have a title on purpose to test how this works.