### PR TITLE
Change path of icons

### DIFF
--- a/docs/api/package.json
+++ b/docs/api/package.json
@@ -3,7 +3,7 @@
   "title": "Example Integration",
   "version": "1.0.0",
   "description": "This is the example integration",
-  "icon": "/img/example-1.0.0/icon.png",
+  "icon": "/package/example-1.0.0/img/icon.png",
   "requirement": {
     "kibana": {
       "version.min": "7.0.0",

--- a/docs/api/search-kibana652.json
+++ b/docs/api/search-kibana652.json
@@ -2,7 +2,7 @@
   {
     "description": "This is the example integration.",
     "download": "/package/example-0.0.5.tar.gz",
-    "icon": "/img/example-0.0.5/icon.png",
+    "icon": "/package/example-0.0.5/img/icon.png",
     "name": "example",
     "version": "0.0.5"
   }

--- a/docs/api/search-kibana721.json
+++ b/docs/api/search-kibana721.json
@@ -2,7 +2,7 @@
   {
     "description": "This is the example integration",
     "download": "/package/example-1.0.0.tar.gz",
-    "icon": "/img/example-1.0.0/icon.png",
+    "icon": "/package/example-1.0.0/img/icon.png",
     "name": "example",
     "title": "Example Integration",
     "version": "1.0.0"

--- a/docs/api/search.json
+++ b/docs/api/search.json
@@ -2,7 +2,7 @@
   {
     "description": "This is the example integration",
     "download": "/package/example-1.0.0.tar.gz",
-    "icon": "/img/example-1.0.0/icon.png",
+    "icon": "/package/example-1.0.0/img/icon.png",
     "name": "example",
     "title": "Example Integration",
     "version": "1.0.0"

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -15,7 +14,6 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
-	"strings"
 	"syscall"
 
 	ucfgYAML "github.com/elastic/go-ucfg/yaml"
@@ -134,7 +132,6 @@ func getRouter() *mux.Router {
 	router.HandleFunc("/search", searchHandler())
 	router.HandleFunc("/package/{name}.tar.gz", targzDownloadHandler())
 	router.HandleFunc("/package/{name}", packageHandler())
-	router.HandleFunc("/img/{name}/{file}", imgHandler)
 	router.PathPrefix("/").HandlerFunc(catchAll())
 
 	return router
@@ -169,7 +166,7 @@ type Package struct {
 }
 
 func (p *Package) getIcon() string {
-	return "/img/" + p.Name + "-" + p.Version + "/icon.png"
+	return "/package/" + p.Name + "-" + p.Version + "/img/icon.png"
 }
 
 type Manifest struct {
@@ -204,12 +201,4 @@ func readManifest(p string) (*Manifest, error) {
 	}
 
 	return m, nil
-}
-
-func readImage(p, file string) ([]byte, error) {
-	// Make sure no relative paths are inserted
-	if strings.Contains(file, "..") {
-		return nil, fmt.Errorf("no relative paths allowed")
-	}
-	return ioutil.ReadFile(packagesPath + "/" + p + "/img/" + file)
 }


### PR DESCRIPTION
This changes the current icon path from `/img/{package}-{version}/icon.png` to `/package/{package}-{version}/img/icon.png`. The reasoning is that directly the assets from the package itself are served so no special handlers are needed in the backend. The other breaking change is that in case no icon exists, a 404 is returned instead of the default icon. It's up the integrations manager to decide what to do for a default icon.

With https://github.com/elastic/integrations-registry/issues/45 the API response for icons will be refactored. For now I left the API response the same, meaning it contains the icon path even if no icon exists, but will change that when tackling #45.