### PR TITLE
Simplify image handling

### DIFF
--- a/dev/package-examples/iptables-1.0.4/manifest.yml
+++ b/dev/package-examples/iptables-1.0.4/manifest.yml
@@ -17,7 +17,7 @@ screenshots:
 - src: /img/kibana-iptables.png
   title: IP Tables Overview dashboard
   size: 1492x1382
-- src: /img/kibana-iptables-ubiquity.png
+- src: /img/kibana-iptables-ubiquiti.png
   title: IP Tables Ubiquity Dashboard
   size: 1492x1464
 

--- a/docs/api/package.json
+++ b/docs/api/package.json
@@ -11,12 +11,12 @@
   },
   "screenshots": [
     {
-      "src": "/img/kibana-iptables.png",
+      "src": "/package/example-1.0.0/img/kibana-iptables.png",
       "title": "IP Tables Overview dashboard",
       "size": "1492x1382"
     },
     {
-      "src": "/img/kibana-iptables-ubiquity.png",
+      "src": "/package/example-1.0.0/img/kibana-iptables-ubiquity.png",
       "title": "IP Tables Ubiquity Dashboard",
       "size": "1492x1464",
       "type": "image/png"

--- a/main.go
+++ b/main.go
@@ -172,21 +172,19 @@ type Manifest struct {
 			Max string `yaml:"version.max" json:"version.max"`
 		} `yaml:"kibana" json:"kibana"`
 	} `yaml:"requirement" json:"requirement"`
-	Screenshots []Screenshot `yaml:"screenshots" json:"screenshots,omitempty"`
-	Icons       []Icon       `yaml:"icons" json:"icons,omitempty"`
+	Screenshots []Image `yaml:"screenshots" json:"screenshots,omitempty"`
+	Icons       []Image `yaml:"icons" json:"icons,omitempty"`
 }
 
-type Screenshot struct {
+type Image struct {
 	Src   string `yaml:"src" json:"src,omitempty"`
 	Title string `yaml:"title" json:"title,omitempty"`
 	Size  string `yaml:"size" json:"size,omitempty"`
 	Type  string `yaml:"type" json:"type,omitempty"`
 }
 
-type Icon struct {
-	Src  string `yaml:"src,omitempty" json:"src,omitempty"`
-	Size string `yaml:"size,omitempty" json:"size,omitempty"`
-	Type string `yaml:"type,omitempty" json:"type,omitempty"`
+func (i Image) getPath(m *Manifest) string {
+	return "/package/" + m.Name + "-" + m.Version + i.Src
 }
 
 func readManifest(p string) (*Manifest, error) {
@@ -204,7 +202,13 @@ func readManifest(p string) (*Manifest, error) {
 
 	if m.Icons != nil {
 		for k, i := range m.Icons {
-			m.Icons[k].Src = "/package/" + m.Name + "-" + m.Version + i.Src
+			m.Icons[k].Src = i.getPath(m)
+		}
+	}
+
+	if m.Screenshots != nil {
+		for k, i := range m.Screenshots {
+			m.Screenshots[k].Src = i.getPath(m)
 		}
 	}
 


### PR DESCRIPTION
This simplifies the handling of icons and screenshots by unifying the data structure. With this it also fixes the paths for the screenshots which before were relative to the package name and now are full paths. An example looks as following:

```
{
  "name": "iptables",
  "title": "IP Tables",
  "version": "1.0.4",
  "description": "iptables logs",
  "requirement": {
    "kibana": {
      "version.min": "6.7.0",
      "version.max": "7.6.0"
    }
  },
  "screenshots": [
    {
      "src": "/package/iptables-1.0.4/img/kibana-iptables.png",
      "title": "IP Tables Overview dashboard",
      "size": "1492x1382"
    },
    {
      "src": "/package/iptables-1.0.4/img/kibana-iptables-ubiquiti.png",
      "title": "IP Tables Ubiquity Dashboard",
      "size": "1492x1464"
    }
  ],
  "icons": [
    {
      "src": "/package/iptables-1.0.4/img/icon.png",
      "size": "1800x1800",
      "type": "image/png"
    }
  ]
}
```