### PR TITLE
Add os.platform as a configurable field to the manifest

### DIFF
--- a/ASSETS.md
+++ b/ASSETS.md
@@ -28,6 +28,7 @@ categories: ["logs", "metrics"]
 # Options are experimental, beta, ga
 release: beta
 compatibility: [1.0.2, 2.0.1]
+os.platform: [darwin, freebsd, linux, macos, openbsd, windows]
 
 requirement:
   elasticsearch:


### PR DESCRIPTION
Not all integrations are available on all platforms. At the moment in the modules this is pure documentation but it would be better to have it defined in the integration directly. For the name of config option, the ECS field name is used.

One challenge with the above is, that not all inputs inside an integration necessarly have the same platform support. The system module is an example here. This should be still handled through the documentation.