### PR TITLE
File reference in docs

### DIFF
--- a/dev/package-examples/longdocs-1.0.4/docs/README.md
+++ b/dev/package-examples/longdocs-1.0.4/docs/README.md
@@ -16,7 +16,7 @@ This is a [link](https://github.com/elastic/integrations-registry) inside the do
 The following file shows how an event might look like:
 
 ```
-{{ file /docs/data.json }}
+{{ > ./data.json }}
 ```
 
 ## Template parts

--- a/dev/package-examples/longdocs-1.0.4/docs/README.md
+++ b/dev/package-examples/longdocs-1.0.4/docs/README.md
@@ -11,6 +11,14 @@ This integration is considered to be in _beta_.
 
 This is a [link](https://github.com/elastic/integrations-registry) inside the docs.
 
+## Examples from a file
+
+The following file shows how an event might look like:
+
+```
+{{ file /docs/data.json }}
+```
+
 ## Template parts
 
 Some part of our documentation will require templated documentation. An example of this is to link to the download links of the Beat with the same version as Kibana. The link below with the link text is an example:

--- a/dev/package-examples/longdocs-1.0.4/docs/data.json
+++ b/dev/package-examples/longdocs-1.0.4/docs/data.json
@@ -1,0 +1,55 @@
+{
+    "@timestamp": "2017-10-12T08:05:34.853Z",
+    "agent": {
+        "hostname": "host.example.com",
+        "name": "host.example.com"
+    },
+    "event": {
+        "dataset": "system.core",
+        "duration": 115000,
+        "module": "system"
+    },
+    "metricset": {
+        "name": "core"
+    },
+    "service": {
+        "type": "system"
+    },
+    "system": {
+        "core": {
+            "id": 0,
+            "idle": {
+                "pct": 0.84,
+                "ticks": 69564411
+            },
+            "iowait": {
+                "pct": 0,
+                "ticks": 419844
+            },
+            "irq": {
+                "pct": 0,
+                "ticks": 0
+            },
+            "nice": {
+                "pct": 0,
+                "ticks": 45632
+            },
+            "softirq": {
+                "pct": 0,
+                "ticks": 189966
+            },
+            "steal": {
+                "pct": 0,
+                "ticks": 0
+            },
+            "system": {
+                "pct": 0.08,
+                "ticks": 6211665
+            },
+            "user": {
+                "pct": 0.08,
+                "ticks": 18833962
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds an example on how part of the docs could be generated from existing files. This is especially useful for showing example data or longer configurations.