### PR TITLE
Add assets list to package endpoint

### DIFF
--- a/p/package.go
+++ b/p/package.go
@@ -1,10 +1,10 @@
 package p
 
 import (
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
-)
 
+	"gopkg.in/yaml.v2"
+)
 
 type Package struct {
 	Name        string  `yaml:"name" json:"name"`
@@ -21,8 +21,9 @@ type Manifest struct {
 			Max string `yaml:"version.max" json:"version.max"`
 		} `yaml:"kibana" json:"kibana"`
 	} `yaml:"requirement" json:"requirement"`
-	Screenshots []Image `yaml:"screenshots,omitempty" json:"screenshots,omitempty"`
-	Icons       []Image `yaml:"icons,omitempty" json:"icons,omitempty"`
+	Screenshots []Image  `yaml:"screenshots,omitempty" json:"screenshots,omitempty"`
+	Icons       []Image  `yaml:"icons,omitempty" json:"icons,omitempty"`
+	Assets      []string `yaml:"assets,omitempty" json:"assets,omitempty"`
 }
 
 type Image struct {
@@ -63,4 +64,3 @@ func ReadManifest(packagesPath, p string) (*Manifest, error) {
 
 	return m, nil
 }
-


### PR DESCRIPTION
An example output looks as following:

```
{
  "name": "iptables",
  "title": "IP Tables",
  "version": "1.0.4",
  "description": "iptables logs",
  "requirement": {
    "kibana": {
      "version.min": "6.7.0",
      "version.max": "7.6.0"
    }
  },
  "screenshots": [
    {
      "src": "/package/iptables-1.0.4/img/kibana-iptables.png",
      "title": "IP Tables Overview dashboard",
      "size": "1492x1382"
    },
    {
      "src": "/package/iptables-1.0.4/img/kibana-iptables-ubiquiti.png",
      "title": "IP Tables Ubiquity Dashboard",
      "size": "1492x1464"
    }
  ],
  "icons": [
    {
      "src": "/package/iptables-1.0.4/img/icon.png",
      "size": "1800x1800",
      "type": "image/png"
    }
  ],
  "assets": [
    "/package/iptables-1.0.4/index.json",
    "/package/iptables-1.0.4/manifest.yml",
    "/package/iptables-1.0.4/docs/index.asciidoc",
    "/package/iptables-1.0.4/fields/fields.yml",
    "/package/iptables-1.0.4/img/icon.png",
    "/package/iptables-1.0.4/img/kibana-iptables-ubiquiti.png",
    "/package/iptables-1.0.4/img/kibana-iptables.png",
    "/package/iptables-1.0.4/elasticsearch/ingest-pipeline/pipeline.json",
    "/package/iptables-1.0.4/filebeat/config/config.yml",
    "/package/iptables-1.0.4/filebeat/config/input.yml",
    "/package/iptables-1.0.4/kibana/dashboard/ceefb9e0-1f51-11e9-93ed-f7e068f4aebb-ecs.json",
    "/package/iptables-1.0.4/kibana/index-pattern/filebeat-*.json",
    "/package/iptables-1.0.4/kibana/search/b3f1b010-1f26-11e9-8ec4-cf5d91a864b3-ecs.json",
    "/package/iptables-1.0.4/kibana/visualization/2599f5e0-1e98-11e9-8ec4-cf5d91a864b3-ecs.json",
    "/package/iptables-1.0.4/kibana/visualization/35fe0910-1f26-11e9-8ec4-cf5d91a864b3-ecs.json",
    "/package/iptables-1.0.4/kibana/visualization/4c913eb0-1f51-11e9-93ed-f7e068f4aebb-ecs.json",
    "/package/iptables-1.0.4/kibana/visualization/683402b0-1f29-11e9-8ec4-cf5d91a864b3-ecs.json",
    "/package/iptables-1.0.4/kibana/visualization/b57b7370-1f1d-11e9-8ec4-cf5d91a864b3-ecs.json",
    "/package/iptables-1.0.4/kibana/visualization/c4394ec0-1efd-11e9-8ec4-cf5d91a864b3-ecs.json",
    "/package/iptables-1.0.4/kibana/visualization/d8cea010-1efd-11e9-8ec4-cf5d91a864b3-ecs.json"
  ]
}
```

Closes #72