### PR TITLE
Add /categories endpoint

### DIFF
--- a/categories.go
+++ b/categories.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/blang/semver"
+
+	"github.com/elastic/integrations-registry/p"
+)
+
+var categoryTitles = map[string]string{
+	"logs":    "Logs",
+	"metrics": "Metrics",
+}
+
+// categoriesHandler is a dynamic handler as it will also allow filtering in the future.
+func categoriesHandler() func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		integrations, err := getIntegrationPackages()
+		if err != nil {
+			notFound(w, err)
+			return
+		}
+
+		packageList := map[string]*p.Manifest{}
+		// Get unique list of newest packages
+		for _, i := range integrations {
+			m, err := p.ReadManifest(packagesPath, i)
+			if err != nil {
+				return
+			}
+
+			// Check if the version exists and if it should be added or not.
+			if p, ok := packageList[m.Name]; ok {
+				newVersion, _ := semver.Make(m.Version)
+				oldVersion, _ := semver.Make(p.Version)
+
+				// Skip addition of package if only lower or equal
+				if newVersion.LTE(oldVersion) {
+					continue
+				}
+			}
+			packageList[m.Name] = m
+		}
+
+		categories := map[string]*Category{}
+
+		for _, p := range packageList {
+			for _, c := range p.Categories {
+				if _, ok := categories[c]; !ok {
+					categories[c] = &Category{
+						Id:    c,
+						Title: c,
+						Count: 0,
+					}
+				}
+
+				categories[c].Count = categories[c].Count + 1
+			}
+		}
+
+		var outputCategories []*Category
+		for _, c := range categories {
+			if title, ok := categoryTitles[c.Title]; ok {
+				c.Title = title
+			}
+			outputCategories = append(outputCategories, c)
+		}
+
+		j, err := json.MarshalIndent(outputCategories, "", "  ")
+		if err != nil {
+			notFound(w, err)
+			return
+		}
+		jsonHeader(w)
+		fmt.Fprint(w, string(j))
+	}
+}
+
+type Category struct {
+	Id    string `yaml:"id" json:"id"`
+	Title string `yaml:"title" json:"title"`
+	Count int    `yaml:"count" json:"count"`
+}

--- a/docs/api/categories.json
+++ b/docs/api/categories.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "logs",
+    "title": "Logs",
+    "count": 1
+  },
+  {
+    "id": "metrics",
+    "title": "Metrics",
+    "count": 1
+  }
+]

--- a/main.go
+++ b/main.go
@@ -83,6 +83,7 @@ func getRouter() *mux.Router {
 	router := mux.NewRouter().StrictSlash(true)
 
 	router.HandleFunc("/search", searchHandler())
+	router.HandleFunc("/categories", categoriesHandler())
 	router.PathPrefix("/").HandlerFunc(catchAll("./public"))
 
 	return router

--- a/main_test.go
+++ b/main_test.go
@@ -32,6 +32,7 @@ func TestEndpoints(t *testing.T) {
 	}{
 		{"/", "", "info.json", catchAll("./public")},
 		{"/search", "/search", "search.json", searchHandler()},
+		{"/categories", "/categories", "categories.json", categoriesHandler()},
 		{"/search?kibana=6.5.2", "/search", "search-kibana652.json", searchHandler()},
 		{"/search?kibana=7.2.1", "/search", "search-kibana721.json", searchHandler()},
 		{"/package/example-1.0.0", "", "package.json", catchAll("./testdata")},

--- a/p/package.go
+++ b/p/package.go
@@ -7,10 +7,11 @@ import (
 )
 
 type Package struct {
-	Name        string  `yaml:"name" json:"name"`
-	Title       *string `yaml:"title,omitempty" json:"title,omitempty"`
-	Version     string  `yaml:"version" json:"version"`
-	Description string  `yaml:"description" json:"description"`
+	Name        string   `yaml:"name" json:"name"`
+	Title       *string  `yaml:"title,omitempty" json:"title,omitempty"`
+	Version     string   `yaml:"version" json:"version"`
+	Description string   `yaml:"description" json:"description"`
+	Categories  []string `yaml:"categories" json:"categories"`
 }
 
 type Manifest struct {

--- a/testdata/package/example-0.0.2/manifest.yml
+++ b/testdata/package/example-0.0.2/manifest.yml
@@ -1,6 +1,7 @@
 name: example
 description: This is the example integration.
 version: 0.0.5
+categories: ["logs"]
 
 requirement:
   elasticsearch:

--- a/testdata/package/example-1.0.0/manifest.yml
+++ b/testdata/package/example-1.0.0/manifest.yml
@@ -2,6 +2,7 @@ name: example
 description: This is the example integration
 version: 1.0.0
 title: Example Integration
+categories: ["logs", "metrics"]
 
 requirement:
   elasticsearch:


### PR DESCRIPTION
The `/categories` endpoint is to serve information about how many packages per category exist. An example output looks as following:

```
[
  {
    "id": "logs",
    "title": "Logs",
    "count": 16
  },
  {
    "id": "metrics",
    "title": "Metrics",
    "count": 14
  }
]
```

For now the output does not support any filtering. It just takes all the newest packages and adds them to the categories. The category titles are hardcoded in the registry code for now. Later on we should validate the titles of each package.

The decision was made for the more complex output already know, so we can add additional fields in the future without breaking the API.

In the future I imagine this endpoint supports the same filtering capabilities as the search endpoint.

Closes https://github.com/elastic/integrations-registry/issues/75