### PR TITLE
Rename package p to util

### DIFF
--- a/categories.go
+++ b/categories.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/blang/semver"
 
-	"github.com/elastic/integrations-registry/p"
+	"github.com/elastic/integrations-registry/util"
 )
 
 var categoryTitles = map[string]string{
@@ -26,10 +26,10 @@ func categoriesHandler() func(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		packageList := map[string]*p.Manifest{}
+		packageList := map[string]*util.Manifest{}
 		// Get unique list of newest packages
 		for _, i := range integrations {
-			m, err := p.ReadManifest(packagesPath, i)
+			m, err := util.ReadManifest(packagesPath, i)
 			if err != nil {
 				return
 			}

--- a/magefile.go
+++ b/magefile.go
@@ -17,7 +17,7 @@ import (
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
 
-	pack "github.com/elastic/integrations-registry/p"
+	"github.com/elastic/integrations-registry/util"
 )
 
 func Check() error {
@@ -114,7 +114,7 @@ func BuildIntegrationPackages() error {
 		}
 
 		// Build package endpoint
-		manifest, err := pack.ReadManifest(".", p)
+		manifest, err := util.ReadManifest(".", p)
 		if err != nil {
 			return err
 		}
@@ -138,7 +138,7 @@ func BuildIntegrationPackages() error {
 	return nil
 }
 
-func getAssets(manifest *pack.Manifest, p string) (err error) {
+func getAssets(manifest *util.Manifest, p string) (err error) {
 	oldDir, err := os.Getwd()
 	if err != nil {
 		return err

--- a/search.go
+++ b/search.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/blang/semver"
 
-	"github.com/elastic/integrations-registry/p"
+	"github.com/elastic/integrations-registry/util"
 )
 
 func searchHandler() func(w http.ResponseWriter, r *http.Request) {
@@ -20,7 +20,7 @@ func searchHandler() func(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		integrationsList := map[string]*p.Manifest{}
+		integrationsList := map[string]*util.Manifest{}
 
 		query := r.URL.Query()
 
@@ -45,7 +45,7 @@ func searchHandler() func(w http.ResponseWriter, r *http.Request) {
 
 		// Checks that only the most recent version of an integration is added to the list
 		for _, i := range integrations {
-			m, err := p.ReadManifest(packagesPath, i)
+			m, err := util.ReadManifest(packagesPath, i)
 			if err != nil {
 				notFound(w, err)
 				return
@@ -99,7 +99,7 @@ func searchHandler() func(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func hasCategory(category string, m *p.Manifest) (bool, error) {
+func hasCategory(category string, m *util.Manifest) (bool, error) {
 	for _, c := range m.Categories {
 		if c == category {
 			return true, nil
@@ -109,7 +109,7 @@ func hasCategory(category string, m *p.Manifest) (bool, error) {
 	return false, nil
 }
 
-func validKibanaVersion(version *semver.Version, m *p.Manifest) (bool, error) {
+func validKibanaVersion(version *semver.Version, m *util.Manifest) (bool, error) {
 	if version != nil {
 		if m.Requirement.Kibana.Max != "" {
 			maxKibana, err := semver.Parse(m.Requirement.Kibana.Max)
@@ -134,7 +134,7 @@ func validKibanaVersion(version *semver.Version, m *p.Manifest) (bool, error) {
 	return true, nil
 }
 
-func servePackages(packagesList map[string]*p.Manifest, w http.ResponseWriter) ([]byte, error) {
+func servePackages(packagesList map[string]*util.Manifest, w http.ResponseWriter) ([]byte, error) {
 
 	// Packages need to be sorted to be always outputted in the same order
 	var keys []string

--- a/util/package.go
+++ b/util/package.go
@@ -1,4 +1,4 @@
-package p
+package util
 
 import (
 	"io/ioutil"


### PR DESCRIPTION
Work with `p` as a package name was not intuitive. Better use util for now.