### PR TITLE
Introduce package filtering in /search endpoint

### DIFF
--- a/categories.go
+++ b/categories.go
@@ -20,7 +20,7 @@ var categoryTitles = map[string]string{
 func categoriesHandler() func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 
-		integrations, err := getIntegrationPackages()
+		integrations, err := getPackages()
 		if err != nil {
 			notFound(w, err)
 			return

--- a/dev/package-examples/multiversion-1.0.3/docs/README.md
+++ b/dev/package-examples/multiversion-1.0.3/docs/README.md
@@ -1,0 +1,3 @@
+# Multi version
+
+There are multiple versions of this package.

--- a/dev/package-examples/multiversion-1.0.3/img/icon.svg
+++ b/dev/package-examples/multiversion-1.0.3/img/icon.svg
@@ -1,0 +1,1 @@
+<?xml version="1.0" ?><svg style="enable-background:new 0 0 50 50;" version="1.1" viewBox="0 0 50 50" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g id="Layer_1"><path d="M21,5H10v4H1v32h9v4h11v4h28V1H21V5z M3,39V11h7v28H3z M12,43v-2V9V7h9v36H12z M23,3h24v44H23v-2V5V3z"/></g><g/></svg>

--- a/dev/package-examples/multiversion-1.0.3/manifest.yml
+++ b/dev/package-examples/multiversion-1.0.3/manifest.yml
@@ -1,0 +1,18 @@
+name: multiversion
+title: Multi Version
+description: >
+  Multiple versions of this integration exist.
+version: 1.0.3
+categories: ["logs", "metrics"]
+release: ga
+license: basic
+
+requirement:
+  kibana:
+    version.min: 6.7.0
+  elasticsearch:
+    version.min: 7.0.1
+
+icons:
+- src: "/img/icon.svg"
+  type: "image/svg+xml"

--- a/dev/package-examples/multiversion-1.0.4/docs/README.md
+++ b/dev/package-examples/multiversion-1.0.4/docs/README.md
@@ -1,0 +1,3 @@
+# Multi version
+
+There are multiple versions of this package.

--- a/dev/package-examples/multiversion-1.0.4/img/icon.svg
+++ b/dev/package-examples/multiversion-1.0.4/img/icon.svg
@@ -1,0 +1,1 @@
+<?xml version="1.0" ?><svg style="enable-background:new 0 0 50 50;" version="1.1" viewBox="0 0 50 50" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g id="Layer_1"><path d="M21,5H10v4H1v32h9v4h11v4h28V1H21V5z M3,39V11h7v28H3z M12,43v-2V9V7h9v36H12z M23,3h24v44H23v-2V5V3z"/></g><g/></svg>

--- a/dev/package-examples/multiversion-1.0.4/manifest.yml
+++ b/dev/package-examples/multiversion-1.0.4/manifest.yml
@@ -1,0 +1,18 @@
+name: multiversion
+title: Multi Version
+description: >
+  Multiple versions of this integration exist.
+version: 1.0.4
+categories: ["logs", "metrics"]
+release: ga
+license: basic
+
+requirement:
+  kibana:
+    version.min: 6.7.0
+  elasticsearch:
+    version.min: 7.0.1
+
+icons:
+- src: "/img/icon.svg"
+  type: "image/svg+xml"

--- a/dev/package-examples/multiversion-1.1.0/docs/README.md
+++ b/dev/package-examples/multiversion-1.1.0/docs/README.md
@@ -1,0 +1,3 @@
+# Multi version
+
+There are multiple versions of this package.

--- a/dev/package-examples/multiversion-1.1.0/img/icon.svg
+++ b/dev/package-examples/multiversion-1.1.0/img/icon.svg
@@ -1,0 +1,1 @@
+<?xml version="1.0" ?><svg style="enable-background:new 0 0 50 50;" version="1.1" viewBox="0 0 50 50" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g id="Layer_1"><path d="M21,5H10v4H1v32h9v4h11v4h28V1H21V5z M3,39V11h7v28H3z M12,43v-2V9V7h9v36H12z M23,3h24v44H23v-2V5V3z"/></g><g/></svg>

--- a/dev/package-examples/multiversion-1.1.0/manifest.yml
+++ b/dev/package-examples/multiversion-1.1.0/manifest.yml
@@ -1,0 +1,18 @@
+name: multiversion
+title: Multi Version
+description: >
+  Multiple versions of this integration exist.
+version: 1.1.0
+categories: ["logs", "metrics"]
+release: ga
+license: basic
+
+requirement:
+  kibana:
+    version.min: 6.7.0
+  elasticsearch:
+    version.min: 7.0.1
+
+icons:
+- src: "/img/icon.svg"
+  type: "image/svg+xml"

--- a/docs/api/search-package-example.json
+++ b/docs/api/search-package-example.json
@@ -1,0 +1,15 @@
+[
+  {
+    "description": "This is the example integration.",
+    "download": "/package/example-0.0.5.tar.gz",
+    "name": "example",
+    "version": "0.0.5"
+  },
+  {
+    "description": "This is the example integration",
+    "download": "/package/example-1.0.0.tar.gz",
+    "name": "example",
+    "title": "Example Integration",
+    "version": "1.0.0"
+  }
+]

--- a/main.go
+++ b/main.go
@@ -89,8 +89,8 @@ func getRouter() *mux.Router {
 	return router
 }
 
-// getIntegrationPackages returns list of available integration packages
-func getIntegrationPackages() ([]string, error) {
+// getPackages returns list of available packages
+func getPackages() ([]string, error) {
 
 	files, err := ioutil.ReadDir(packagesPath)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -37,6 +37,7 @@ func TestEndpoints(t *testing.T) {
 		{"/search?kibana=7.2.1", "/search", "search-kibana721.json", searchHandler()},
 		{"/search?category=metrics", "/search", "search-category-metrics.json", searchHandler()},
 		{"/search?category=logs", "/search", "search-category-logs.json", searchHandler()},
+		{"/search?package=example", "/search", "search-package-example.json", searchHandler()},
 		{"/package/example-1.0.0", "", "package.json", catchAll("./testdata")},
 	}
 


### PR DESCRIPTION
To show which versions of a package exist, the `/search` endpoint must support filtering by a package and then return all versions of this package.

This introduces the parameter `package` with which queries like `/search?package=mysql` can be created.

These results can be used for showing a drop down when upgrading a version to show which other versions exist.