### PR TITLE
Cleanup code around manifest, package and integration naming

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,8 +89,8 @@ func getRouter() *mux.Router {
 	return router
 }
 
-// getPackages returns list of available packages
-func getPackages() ([]string, error) {
+// getPackagePaths returns list of available packages
+func getPackagePaths() ([]string, error) {
 
 	files, err := ioutil.ReadDir(packagesPath)
 	if err != nil {


### PR DESCRIPTION
There was a mix of using package, manifest or integration for the same thing in the code because of historical reasons. This PR introduces the Package struct with multiple methods and package is now used across the code. The methods on the Package struct also simplify the implementation of the search and categories endpoint.

Validation of the manifest.yml file for the version now happens when creating a package instance. This makes later checks for the version simpler and we detect issues earlier. The errors already show up on build time because of this.

Some of the docs comments were cleaned up or extended for better readability of the code.

Having a separate Package struct with methods also helps adding further unit tests without having to build packages.

No functionality was changed in this PR.