### PR TITLE
Refactoring and cleaning up the magefile

### DIFF
--- a/categories.go
+++ b/categories.go
@@ -24,7 +24,7 @@ type Category struct {
 func categoriesHandler() func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 
-		packagePaths, err := getPackagePaths()
+		packagePaths, err := util.GetPackagePaths(packagesBasePath)
 		if err != nil {
 			notFound(w, err)
 			return
@@ -33,7 +33,7 @@ func categoriesHandler() func(w http.ResponseWriter, r *http.Request) {
 		packageList := map[string]*util.Package{}
 		// Get unique list of newest packages
 		for _, i := range packagePaths {
-			p, err := util.NewPackage(packagesPath, i)
+			p, err := util.NewPackage(packagesBasePath, i)
 			if err != nil {
 				return
 			}

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ package main
 import (
 	"context"
 	"flag"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -20,10 +19,10 @@ import (
 )
 
 var (
-	packagesPath string
-	address      string
-	version      = "0.0.1"
-	configPath   = "config.yml"
+	packagesBasePath string
+	address          string
+	version          = "0.0.1"
+	configPath       = "config.yml"
 )
 
 func init() {
@@ -44,7 +43,7 @@ func main() {
 		log.Print(err)
 		os.Exit(1)
 	}
-	packagesPath = config.PackagesPath
+	packagesBasePath = config.PackagesPath
 
 	server := &http.Server{Addr: address, Handler: getRouter()}
 
@@ -87,24 +86,4 @@ func getRouter() *mux.Router {
 	router.PathPrefix("/").HandlerFunc(catchAll("./public"))
 
 	return router
-}
-
-// getPackagePaths returns list of available packages
-func getPackagePaths() ([]string, error) {
-
-	files, err := ioutil.ReadDir(packagesPath)
-	if err != nil {
-		return nil, err
-	}
-
-	var packages []string
-	for _, f := range files {
-		if !f.IsDir() {
-			continue
-		}
-
-		packages = append(packages, f.Name())
-	}
-
-	return packages, nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -22,7 +22,7 @@ var (
 
 func TestEndpoints(t *testing.T) {
 
-	packagesPath = "./testdata/package"
+	packagesBasePath = "./testdata/package"
 
 	tests := []struct {
 		endpoint string

--- a/search.go
+++ b/search.go
@@ -46,7 +46,7 @@ func searchHandler() func(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		packagePaths, err := getPackagePaths()
+		packagePaths, err := util.GetPackagePaths(packagesBasePath)
 		if err != nil {
 			notFound(w, err)
 			return
@@ -56,7 +56,7 @@ func searchHandler() func(w http.ResponseWriter, r *http.Request) {
 
 		// Checks that only the most recent version of an integration is added to the list
 		for _, path := range packagePaths {
-			p, err := util.NewPackage(packagesPath, path)
+			p, err := util.NewPackage(packagesBasePath, path)
 			if err != nil {
 				notFound(w, err)
 				return

--- a/testdata/package/foo-1.0.0/index.json
+++ b/testdata/package/foo-1.0.0/index.json
@@ -13,7 +13,6 @@
     }
   },
   "assets": [
-    "/package/foo-1.0.0/index.json",
     "/package/foo-1.0.0/manifest.yml"
   ]
 }

--- a/util/packages.go
+++ b/util/packages.go
@@ -1,0 +1,23 @@
+package util
+
+import "io/ioutil"
+
+// GetPackagePaths returns list of available packages, one for each version.
+func GetPackagePaths(packagesPath string) ([]string, error) {
+
+	files, err := ioutil.ReadDir(packagesPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var packages []string
+	for _, f := range files {
+		if !f.IsDir() {
+			continue
+		}
+
+		packages = append(packages, f.Name())
+	}
+
+	return packages, nil
+}


### PR DESCRIPTION
The magefile has become a bit messy with all the recent changes. This make some code reusable and extracts code which more belongs into the `Packages` struct. This simplifies the magefile and should make the code easier to read.