### PR TITLE
Add package type to manifest file

### DIFF
--- a/ASSETS.md
+++ b/ASSETS.md
@@ -27,6 +27,9 @@ version: 0.0.2
 categories: ["logs", "metrics"]
 # Options are experimental, beta, ga
 release: beta
+# The package type. The options for now are [integration, solution], more type might be added in the future.
+# The default type is integration and will be set if empty.
+type: integration
 compatibility: [1.0.2, 2.0.1]
 os.platform: [darwin, freebsd, linux, macos, openbsd, windows]
 

--- a/dev/package-examples/coredns-1.0.1/manifest.yml
+++ b/dev/package-examples/coredns-1.0.1/manifest.yml
@@ -9,6 +9,7 @@ version: 1.0.1
 categories: ["logs", "metrics"]
 release: beta
 license: basic
+type: integration
 
 requirement:
   kibana:

--- a/dev/package-examples/multiversion-1.0.4/manifest.yml
+++ b/dev/package-examples/multiversion-1.0.4/manifest.yml
@@ -6,6 +6,7 @@ version: 1.0.4
 categories: ["logs", "metrics"]
 release: ga
 license: basic
+type: integration
 
 requirement:
   kibana:

--- a/docs/api/search-category-logs.json
+++ b/docs/api/search-category-logs.json
@@ -4,6 +4,7 @@
     "download": "/package/example-1.0.0.tar.gz",
     "name": "example",
     "title": "Example Integration",
+    "type": "integration",
     "version": "1.0.0"
   }
 ]

--- a/docs/api/search-category-metrics.json
+++ b/docs/api/search-category-metrics.json
@@ -4,6 +4,7 @@
     "download": "/package/example-1.0.0.tar.gz",
     "name": "example",
     "title": "Example Integration",
+    "type": "integration",
     "version": "1.0.0"
   },
   {
@@ -11,6 +12,7 @@
     "download": "/package/foo-1.0.0.tar.gz",
     "name": "foo",
     "title": "Foo",
+    "type": "solution",
     "version": "1.0.0"
   }
 ]

--- a/docs/api/search-kibana652.json
+++ b/docs/api/search-kibana652.json
@@ -3,6 +3,7 @@
     "description": "This is the example integration.",
     "download": "/package/example-0.0.5.tar.gz",
     "name": "example",
+    "type": "integration",
     "version": "0.0.5"
   }
 ]

--- a/docs/api/search-kibana721.json
+++ b/docs/api/search-kibana721.json
@@ -4,6 +4,7 @@
     "download": "/package/example-1.0.0.tar.gz",
     "name": "example",
     "title": "Example Integration",
+    "type": "integration",
     "version": "1.0.0"
   },
   {
@@ -11,6 +12,7 @@
     "download": "/package/foo-1.0.0.tar.gz",
     "name": "foo",
     "title": "Foo",
+    "type": "solution",
     "version": "1.0.0"
   }
 ]

--- a/docs/api/search-package-example.json
+++ b/docs/api/search-package-example.json
@@ -3,6 +3,7 @@
     "description": "This is the example integration.",
     "download": "/package/example-0.0.5.tar.gz",
     "name": "example",
+    "type": "integration",
     "version": "0.0.5"
   },
   {
@@ -10,6 +11,7 @@
     "download": "/package/example-1.0.0.tar.gz",
     "name": "example",
     "title": "Example Integration",
+    "type": "integration",
     "version": "1.0.0"
   }
 ]

--- a/docs/api/search.json
+++ b/docs/api/search.json
@@ -4,6 +4,7 @@
     "download": "/package/example-1.0.0.tar.gz",
     "name": "example",
     "title": "Example Integration",
+    "type": "integration",
     "version": "1.0.0"
   },
   {
@@ -11,6 +12,7 @@
     "download": "/package/foo-1.0.0.tar.gz",
     "name": "foo",
     "title": "Foo",
+    "type": "solution",
     "version": "1.0.0"
   }
 ]

--- a/search.go
+++ b/search.go
@@ -136,6 +136,7 @@ func getPackageOutput(packagesList map[string]map[string]*util.Package) ([]byte,
 			"name":        m.Name,
 			"description": m.Description,
 			"version":     m.Version,
+			"type":        m.Type,
 			"download":    "/package/" + m.Name + "-" + m.Version + ".tar.gz",
 		}
 		if m.Title != nil {

--- a/testdata/package/example-1.0.0/manifest.yml
+++ b/testdata/package/example-1.0.0/manifest.yml
@@ -3,6 +3,7 @@ description: This is the example integration
 version: 1.0.0
 title: Example Integration
 categories: ["logs", "metrics"]
+type: integration
 
 requirement:
   elasticsearch:

--- a/testdata/package/foo-1.0.0/manifest.yml
+++ b/testdata/package/foo-1.0.0/manifest.yml
@@ -3,6 +3,7 @@ description: This is the foo integration
 version: 1.0.0
 title: Foo
 categories: [metrics]
+type: solution
 
 requirement:
   elasticsearch:

--- a/util/package.go
+++ b/util/package.go
@@ -11,12 +11,15 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const defaultType = "integration"
+
 type Package struct {
 	Name          string  `yaml:"name" json:"name"`
 	Title         *string `yaml:"title,omitempty" json:"title,omitempty"`
 	Version       string  `yaml:"version" json:"version"`
 	versionSemVer semver.Version
 	Description   string   `yaml:"description" json:"description"`
+	Type          string   `yaml:"type" json:"type"`
 	Categories    []string `yaml:"categories" json:"categories"`
 	Requirement   struct {
 		Kibana struct {
@@ -55,6 +58,10 @@ func NewPackage(basePath, packageName string) (*Package, error) {
 	err = yaml.Unmarshal(manifest, p)
 	if err != nil {
 		return nil, err
+	}
+
+	if p.Type == "" {
+		p.Type = defaultType
 	}
 
 	if p.Icons != nil {


### PR DESCRIPTION
Currently the type is not used and the default type is 'integration'. But this gives us the option in the future to also introduce packages which are not integrations, for example for solutions.