### PR TITLE
Add Validation of package

### DIFF
--- a/dev/package-generated/kafka-1.0.1/manifest.yml
+++ b/dev/package-generated/kafka-1.0.1/manifest.yml
@@ -1,6 +1,6 @@
 name: kafka
 description: Kafka Logs and metrics
-
+title: Kafka
 version: 1.0.1
 categories: ["logs", "metrics"]
 release: beta

--- a/dev/package-generated/kibana-1.3.2/manifest.yml
+++ b/dev/package-generated/kibana-1.3.2/manifest.yml
@@ -1,6 +1,6 @@
 name: kibana
 description: Kibana Logs and metrics
-
+title: Kibana
 version: 1.3.2
 categories: ["logs", "metrics"]
 release: beta

--- a/dev/package-generated/mysql-1.0.1/manifest.yml
+++ b/dev/package-generated/mysql-1.0.1/manifest.yml
@@ -1,6 +1,6 @@
 name: mysql
 description: Mysql Logs and metrics
-
+title: MySQL
 version: 1.0.1
 categories: ["logs", "metrics"]
 release: beta

--- a/dev/package-generated/system-2.0.1/manifest.yml
+++ b/dev/package-generated/system-2.0.1/manifest.yml
@@ -1,6 +1,6 @@
 name: system
 description: System SQL Logs and metrics
-
+title: System
 version: 2.0.1
 categories: ["logs", "metrics"]
 release: beta

--- a/dev/package-generated/traefik-1.0.2/manifest.yml
+++ b/dev/package-generated/traefik-1.0.2/manifest.yml
@@ -1,6 +1,6 @@
 name: traefik
 description: Traefik SQL Logs and metrics
-
+title: Traefik
 version: 1.0.2
 categories: ["logs", "metrics"]
 release: beta

--- a/magefile.go
+++ b/magefile.go
@@ -128,6 +128,12 @@ func buildPackage(packagesBasePath, path string) error {
 		return err
 	}
 
+	// Checks if the package is valid
+	err = p.Validate()
+	if err != nil {
+		return fmt.Errorf("Invalid package %s-%s: %s", p.Name, p.Version, err)
+	}
+
 	err = p.LoadAssets(path)
 	if err != nil {
 		return err

--- a/util/package.go
+++ b/util/package.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -183,5 +184,18 @@ func (p *Package) LoadAssets(packagePath string) (err error) {
 		a = "/package/" + packagePath + "/" + a
 		p.Assets = append(p.Assets, a)
 	}
+	return nil
+}
+
+func (p *Package) Validate() error {
+
+	if p.Title == nil || *p.Title == "" {
+		return fmt.Errorf("no title set")
+	}
+
+	if p.Description == "" {
+		return fmt.Errorf("no description set")
+	}
+
 	return nil
 }

--- a/util/package_test.go
+++ b/util/package_test.go
@@ -1,0 +1,51 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	title = "foo"
+)
+var packageTests = []struct {
+	p           Package
+	valid       bool
+	description string
+}{
+	{
+		Package{},
+		false,
+		"empty",
+	},
+	{
+		Package{
+			Title: &title,
+		},
+		false,
+		"missing description",
+	},
+	{
+		Package{
+			Title:       &title,
+			Description: "my description",
+		},
+		true,
+		"complete",
+	},
+}
+
+func TestValidate(t *testing.T) {
+	for _, tt := range packageTests {
+		t.Run(tt.description, func(t *testing.T) {
+			err := tt.p.Validate()
+
+			if err != nil {
+				assert.False(t, tt.valid)
+			} else {
+				assert.True(t, tt.valid)
+			}
+		})
+	}
+}


### PR DESCRIPTION
To make sure the registry only serves valid packages, packages should be validated during build time. For this a `Package.Validate() error` method was added. For not it is simple and only checks for title and description but more checks should be added in the future.

The packages which were not valid were updated.