### PR TITLE
Add caching headers to all responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Add validation check that Kibana min/max are valid semver versions. [#99](https://github.com/elastic/integrations-registry/pull/99)
-* Adding Cache-Control max-age headers to all http responses set to 1h.
+* Adding Cache-Control max-age headers to all http responses set to 1h. [#101](https://github.com/elastic/integrations-registry/pull/101)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Add validation check that Kibana min/max are valid semver versions. [#99](https://github.com/elastic/integrations-registry/pull/99)
+* Adding Cache-Control max-age headers to all http responses set to 1h.
 
 ### Changed
 

--- a/categories.go
+++ b/categories.go
@@ -23,6 +23,7 @@ type Category struct {
 // categoriesHandler is a dynamic handler as it will also allow filtering in the future.
 func categoriesHandler() func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
+		cacheHeaders(w)
 
 		packagePaths, err := util.GetPackagePaths(packagesBasePath)
 		if err != nil {

--- a/handler.go
+++ b/handler.go
@@ -22,6 +22,7 @@ func notFound(w http.ResponseWriter, err error) {
 
 func catchAll(publicPath string) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
+		cacheHeaders(w)
 
 		path := r.RequestURI
 
@@ -85,4 +86,9 @@ func sendHeader(w http.ResponseWriter, r *http.Request) {
 		// Using json as the default header
 		w.Header().Set("Content-Type", "application/json")
 	}
+}
+
+func cacheHeaders(w http.ResponseWriter) {
+	w.Header().Add("Cache-Control", "max-age="+cacheTime)
+	w.Header().Add("Cache-Control", "public")
 }

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 
 	ucfgYAML "github.com/elastic/go-ucfg/yaml"
@@ -22,6 +23,7 @@ var (
 	packagesBasePath string
 	address          string
 	configPath       = "config.yml"
+	cacheTime        = strconv.Itoa(60 * 60) // 1 hour
 )
 
 func init() {

--- a/main_test.go
+++ b/main_test.go
@@ -79,4 +79,5 @@ func runEndpoint(t *testing.T, endpoint, path, file string, handler func(w http.
 	}
 
 	assert.Equal(t, string(data), recorder.Body.String())
+	assert.Equal(t, recorder.Header()["Cache-Control"], []string{"max-age=" + cacheTime, "public"})
 }

--- a/search.go
+++ b/search.go
@@ -14,6 +14,7 @@ import (
 
 func searchHandler() func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
+		cacheHeaders(w)
 
 		query := r.URL.Query()
 


### PR DESCRIPTION
The content of the registry only changes if a new package is added or if the registry is updated. Because of this, all responses can be cached. Caching headers are introduced for all requests and the caching time is currently set to 1h. This could be increased in the future especially for the `catchAll` endpoint as these assets basically never change.