### PR TITLE
Prepare release 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security
+
+## [0.1.0]
+
+First tagged release. No changelog existed so far.

--- a/docs/api/info.json
+++ b/docs/api/info.json
@@ -1,4 +1,4 @@
 {
     "service.name": "integration-registry",
-    "version": "0.0.1"
+    "version": "0.1.0"
 }

--- a/magefile.go
+++ b/magefile.go
@@ -150,7 +150,7 @@ func buildPackage(packagesBasePath, path string) error {
 // For now only containing the version.
 func BuildRootFile() error {
 	rootData := map[string]string{
-		"version":      "0.0.1",
+		"version":      "0.1.0",
 		"service.name": "integration-registry",
 	}
 

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ import (
 var (
 	packagesBasePath string
 	address          string
-	version          = "0.0.1"
+	version          = "0.1.0"
 	configPath       = "config.yml"
 )
 

--- a/testdata/index.json
+++ b/testdata/index.json
@@ -1,4 +1,4 @@
 {
     "service.name": "integration-registry",
-    "version": "0.0.1"
+    "version": "0.1.0"
 }


### PR DESCRIPTION
This is the first release that should be tagged. So far the changelog was not used but that will change now. All development will still happen on top of master.

All files were updated for the this release. Breaking changes might still happen until we hit 1.0 but they will be documented.