### PR TITLE
Add .dockerignore file for slimmer image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
+.DS_Store
+integrations-registry
+
 .idea
 build
 public/*

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.idea
+build
+public/*


### PR DESCRIPTION
Adding the same files to .dockerignore as we had in the .gitignore files as these are not needed to build the container. This should make sure if a container is built locally but some of the .gitignore files are modified, it still builds to container. With this, less unncessary files should end up in the container.