### PR TITLE
Update to 0.2.0 as next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,10 @@
-NOTE: The changelog is currently not used.
-
 # Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased](https://github.com/elastic/integrations-registry/compare/v0.1.0...master)
 
 ### Added
 

--- a/docs/api/info.json
+++ b/docs/api/info.json
@@ -1,4 +1,4 @@
 {
     "service.name": "integration-registry",
-    "version": "0.1.0"
+    "version": "0.2.0"
 }

--- a/magefile.go
+++ b/magefile.go
@@ -150,7 +150,7 @@ func buildPackage(packagesBasePath, path string) error {
 // For now only containing the version.
 func BuildRootFile() error {
 	rootData := map[string]string{
-		"version":      "0.1.0",
+		"version":      "0.2.0",
 		"service.name": "integration-registry",
 	}
 

--- a/main.go
+++ b/main.go
@@ -21,7 +21,6 @@ import (
 var (
 	packagesBasePath string
 	address          string
-	version          = "0.1.0"
 	configPath       = "config.yml"
 )
 

--- a/testdata/index.json
+++ b/testdata/index.json
@@ -1,4 +1,4 @@
 {
     "service.name": "integration-registry",
-    "version": "0.1.0"
+    "version": "0.2.0"
 }


### PR DESCRIPTION
As 0.1.0 release was tagged, all the version notes must be updated to 0.2.0 which should be the next release.

Note: There are too many places which need updating and it should be just one in the future, but this will need some automation.