### PR TITLE
Add pipeline reference example to coredns

### DIFF
--- a/dev/package-examples/coredns-1.0.1/agent/config/input.yml
+++ b/dev/package-examples/coredns-1.0.1/agent/config/input.yml
@@ -1,0 +1,6 @@
+- type: logs
+  paths:
+    - /var/log/coredns.log
+  # This must be identical to the name of the pipeline file (without .yml)
+  pipeline: {{pipeline-entry}}
+

--- a/dev/package-examples/coredns-1.0.1/filebeat/config/config.yml
+++ b/dev/package-examples/coredns-1.0.1/filebeat/config/config.yml
@@ -4,4 +4,5 @@ paths:
 - {{$path}}
   {{ end }}
 tags: {{.tags}}
+pipeline: {{pipeline-entry}}
 processors:


### PR DESCRIPTION
Pipelines are input specific. Currently there is no simple way for the integrations manager to know which pipeline should be reference in an input. This introduces the convention that the pipeline name must be a variable which matches one of the pipeline file names in the package.

On creating the pipeline instance, the integrations manager will change and prefix the name. The above convention makes it possible to convert it in both places. As an example: The package has an ingest pipeline `foo.yml` or `foo.json`, in the input it will reference `foo`. Then the integration manager builds the datasource and calls it `bar-foo`. It will the replace the input variable with `bar-foo`.

This also has consequences on https://github.com/elastic/integrations/pull/3. It means the developer building integrations must ensure that no two pipelines have the same name in one package.

To make sure the name in an input matches a pipeline, later on also a validation step should be added.