### PR TITLE
Change empty search response from null to []

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Change empty /search API output from `null` to `[]`.
+
 ### Deprecated
 
 ### Removed

--- a/search.go
+++ b/search.go
@@ -147,5 +147,10 @@ func getPackageOutput(packagesList map[string]map[string]util.Package) ([]byte, 
 		output = append(output, data)
 	}
 
+	// Instead of return `null` in case of an empty array, return []
+	if len(output) == 0 {
+		return []byte("[]"), nil
+	}
+
 	return json.MarshalIndent(output, "", "  ")
 }


### PR DESCRIPTION
So far if the filter on the `/search` endpoint returned no results, it returned `null`. To still have an array type, it should return `[]` instead. This changes the behaviour.