### PR TITLE
Move package generation to its own binary

### DIFF
--- a/dev/generator/main.go
+++ b/dev/generator/main.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/magefile/mage/sh"
+
+	"github.com/elastic/integrations-registry/util"
+)
+
+const (
+	packageDirName = "package"
+)
+
+func main() {
+	// Directory with a list of packages inside
+	var sourceDir string
+	// Target public directory where the generated packages should end up in
+	var publicDir string
+
+	flag.StringVar(&sourceDir, "sourceDir", "", "Path to the source packages")
+	flag.StringVar(&publicDir, "publicDir", "", "Path to the public directory ")
+	flag.Parse()
+
+	if sourceDir == "" || publicDir == "" {
+		log.Fatal("sourceDir and publicDir must be set")
+		os.Exit(1)
+	}
+
+	if err := Build(sourceDir, publicDir); err != nil {
+		log.Fatal(err)
+		os.Exit(1)
+	}
+}
+
+func Build(sourceDir, publicDir string) error {
+
+	err := BuildPackages(sourceDir, publicDir+"/"+packageDirName)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// CopyPackages copies the files of a package to the public directory
+func CopyPackage(src, dst string) error {
+	fmt.Println(">> Copy package: " + src)
+	os.MkdirAll(dst, 0755)
+	err := sh.RunV("cp", "-a", src, dst)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// BuildPackage rebuilds the zip files inside packages
+func BuildPackages(sourceDir, packagesPath string) error {
+
+	dirs, err := ioutil.ReadDir(sourceDir)
+	if err != nil {
+		return err
+	}
+
+	for _, d := range dirs {
+
+		packageName := d.Name()
+		if !d.IsDir() {
+			continue
+		}
+
+		err := CopyPackage(sourceDir+"/"+packageName, packagesPath)
+		if err != nil {
+			return err
+		}
+
+		p, err := util.NewPackage(packagesPath, packageName)
+		if err != nil {
+			return err
+		}
+
+		err = buildPackage(packagesPath, *p)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func buildPackage(packagesBasePath string, p util.Package) error {
+
+	// Change path to simplify tar command
+	currentPath, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	err = os.Chdir(packagesBasePath)
+	if err != nil {
+		return err
+	}
+	defer os.Chdir(currentPath)
+
+	err = sh.RunV("tar", "cvzf", p.GetPath()+".tar.gz", filepath.Base(p.GetPath())+"/")
+	if err != nil {
+		return fmt.Errorf("Error creating package: %s: %s", p.GetPath(), err)
+	}
+
+	// Checks if the package is valid
+	err = p.Validate()
+	if err != nil {
+		return fmt.Errorf("Invalid package: %s: %s", p.GetPath(), err)
+	}
+
+	err = p.LoadAssets(p.GetPath())
+	if err != nil {
+		return err
+	}
+
+	err = writeJsonFile(p, p.GetPath()+"/index.json")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func writeJsonFile(v interface{}, path string) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(path, data, 0644)
+}


### PR DESCRIPTION
Generating a package to be served by the package registry can be used in different places. This extracts the generation of it to its own binary. The binary can be found under `dev/generator` and be built with `go build .`.

The binary takes 2 params:

* `sourceDir`: Path to the source directory of the packages
* `publicDir`: Public directory where the packages should be copied to and built

This might look like `go run . -sourceDir=../packages -publicDir=./public`