### PR TITLE
Add Docker healthcheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Remove not needed files in Docker image. [#106](https://github.com/elastic/integrations-registry/pull/106)
 * Add healthcheck to docker file. [#115](https://github.com/elastic/integrations-registry/pull/115)
 
-### Changed
-
-* Change empty /search API output from `null` to `[]`.
-
 ### Deprecated
 
 ### Known Issue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add .dockerignore file for slimmer image. [#104](https://github.com/elastic/integrations-registry/pull/104)
 * Move package generation to its own package. [#112](https://github.com/elastic/integrations-registry/pull/112)
 * Remove not needed files in Docker image. [#106](https://github.com/elastic/integrations-registry/pull/106)
+* Add healthcheck to docker file. [#115](https://github.com/elastic/integrations-registry/pull/115)
+
+### Changed
+
+* Change empty /search API output from `null` to `[]`.
 
 ### Deprecated
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,3 +24,5 @@ RUN rm -rf dev
 ENTRYPOINT ["go", "run", "."]
 # Make sure it's accessible from outside the container
 CMD ["--address=0.0.0.0:8080"]
+
+HEALTHCHECK --interval=1s --retries=30 CMD curl --silent --fail localhost:8080/ || exit 1

--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ docker build --rm -t integrations_registry:latest .
 docker run -i -t -p 8080:8080 $(docker images -q integrations_registry:latest)
 ```
 
+### Healthcheck
+
+For Docker / Kubernetes the `/` endpoint can be queried. As soon as `/` returns a 200, the service is ready.
+
 ## Generated Example packages
 
 For easier testing of the integrations manager, the registry allows to generate some example packages. The packages


### PR DESCRIPTION
The healthceck is useful in Docker environments. All the preloading of packages happens before the http Server is started. Because of this the `/` endpoint is a good healthcheck indicator. As the registry is never started in error cases, no special healthcheck endpoint is needed.