### PR TITLE
Make cache time configurable per endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Move package generation to its own package. [#112](https://github.com/elastic/integrations-registry/pull/112)
 * Remove not needed files in Docker image. [#106](https://github.com/elastic/integrations-registry/pull/106)
 * Add healthcheck to docker file. [#115](https://github.com/elastic/integrations-registry/pull/115)
+* Make caching headers configurable per endpoint. [#116](https://github.com/elastic/integrations-registry/pull/116)
 
 ### Deprecated
 

--- a/categories.go
+++ b/categories.go
@@ -20,9 +20,9 @@ type Category struct {
 }
 
 // categoriesHandler is a dynamic handler as it will also allow filtering in the future.
-func categoriesHandler() func(w http.ResponseWriter, r *http.Request) {
+func categoriesHandler(cacheTime string) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		cacheHeaders(w)
+		cacheHeaders(w, cacheTime)
 
 		packages, err := util.GetPackages(packagesBasePath)
 		if err != nil {

--- a/handler.go
+++ b/handler.go
@@ -20,9 +20,9 @@ func notFound(w http.ResponseWriter, err error) {
 	http.Error(w, errString, http.StatusNotFound)
 }
 
-func catchAll(publicPath string) func(w http.ResponseWriter, r *http.Request) {
+func catchAll(publicPath, cacheTime string) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		cacheHeaders(w)
+		cacheHeaders(w, cacheTime)
 
 		path := r.RequestURI
 
@@ -88,7 +88,7 @@ func sendHeader(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func cacheHeaders(w http.ResponseWriter) {
+func cacheHeaders(w http.ResponseWriter, cacheTime string) {
 	w.Header().Add("Cache-Control", "max-age="+cacheTime)
 	w.Header().Add("Cache-Control", "public")
 }

--- a/main.go
+++ b/main.go
@@ -25,7 +25,11 @@ var (
 	packagesBasePath string
 	address          string
 	configPath       = "config.yml"
-	cacheTime        = strconv.Itoa(60 * 60) // 1 hour
+
+	// Cache times for the different endpoints
+	searchCacheTime     = strconv.Itoa(60 * 60)      // 1 hour
+	categoriesCacheTime = strconv.Itoa(60 * 60)      // 1 hour
+	catchAllCacheTime   = strconv.Itoa(24 * 60 * 60) // 24 hour
 )
 
 func init() {
@@ -92,9 +96,9 @@ func getConfig() (*Config, error) {
 func getRouter() *mux.Router {
 	router := mux.NewRouter().StrictSlash(true)
 
-	router.HandleFunc("/search", searchHandler())
-	router.HandleFunc("/categories", categoriesHandler())
-	router.PathPrefix("/").HandlerFunc(catchAll("./public"))
+	router.HandleFunc("/search", searchHandler(searchCacheTime))
+	router.HandleFunc("/categories", categoriesHandler(categoriesCacheTime))
+	router.PathPrefix("/").HandlerFunc(catchAll("./public", catchAllCacheTime))
 
 	return router
 }

--- a/main_test.go
+++ b/main_test.go
@@ -17,7 +17,8 @@ import (
 )
 
 var (
-	generateFlag = flag.Bool("generate", false, "Write golden files")
+	generateFlag  = flag.Bool("generate", false, "Write golden files")
+	testCacheTime = "1"
 )
 
 func TestEndpoints(t *testing.T) {
@@ -30,15 +31,15 @@ func TestEndpoints(t *testing.T) {
 		file     string
 		handler  func(w http.ResponseWriter, r *http.Request)
 	}{
-		{"/", "", "info.json", catchAll("./testdata")},
-		{"/search", "/search", "search.json", searchHandler()},
-		{"/categories", "/categories", "categories.json", categoriesHandler()},
-		{"/search?kibana=6.5.2", "/search", "search-kibana652.json", searchHandler()},
-		{"/search?kibana=7.2.1", "/search", "search-kibana721.json", searchHandler()},
-		{"/search?category=metrics", "/search", "search-category-metrics.json", searchHandler()},
-		{"/search?category=logs", "/search", "search-category-logs.json", searchHandler()},
-		{"/search?package=example", "/search", "search-package-example.json", searchHandler()},
-		{"/package/example-1.0.0", "", "package.json", catchAll("./testdata")},
+		{"/", "", "info.json", catchAll("./testdata", testCacheTime)},
+		{"/search", "/search", "search.json", searchHandler(testCacheTime)},
+		{"/categories", "/categories", "categories.json", categoriesHandler(testCacheTime)},
+		{"/search?kibana=6.5.2", "/search", "search-kibana652.json", searchHandler(testCacheTime)},
+		{"/search?kibana=7.2.1", "/search", "search-kibana721.json", searchHandler(testCacheTime)},
+		{"/search?category=metrics", "/search", "search-category-metrics.json", searchHandler(testCacheTime)},
+		{"/search?category=logs", "/search", "search-category-logs.json", searchHandler(testCacheTime)},
+		{"/search?package=example", "/search", "search-package-example.json", searchHandler(testCacheTime)},
+		{"/package/example-1.0.0", "", "package.json", catchAll("./testdata", testCacheTime)},
 	}
 
 	for _, test := range tests {
@@ -79,5 +80,5 @@ func runEndpoint(t *testing.T, endpoint, path, file string, handler func(w http.
 	}
 
 	assert.Equal(t, string(data), recorder.Body.String())
-	assert.Equal(t, recorder.Header()["Cache-Control"], []string{"max-age=" + cacheTime, "public"})
+	assert.Equal(t, recorder.Header()["Cache-Control"], []string{"max-age=" + testCacheTime, "public"})
 }

--- a/search.go
+++ b/search.go
@@ -16,9 +16,9 @@ import (
 	"github.com/elastic/integrations-registry/util"
 )
 
-func searchHandler() func(w http.ResponseWriter, r *http.Request) {
+func searchHandler(cacheTime string) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		cacheHeaders(w)
+		cacheHeaders(w, cacheTime)
 
 		query := r.URL.Query()
 


### PR DESCRIPTION
Before all endpoints had the same cache time. But search and categories should have a shorter cache time then the catchAll endpoint which serves the static files.