### PR TITLE
Remove packages.path config and replace it with public_dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Known Issue
 
+### Breaking change
+
+* Remove `packages.path` config and replace it with `public_dir` config. [#](https://github.com/elastic/integrations-registry/pull/)
+
 ## [0.1.0]
 
 First tagged release. No changelog existed so far.

--- a/categories.go
+++ b/categories.go
@@ -20,7 +20,7 @@ type Category struct {
 }
 
 // categoriesHandler is a dynamic handler as it will also allow filtering in the future.
-func categoriesHandler(cacheTime string) func(w http.ResponseWriter, r *http.Request) {
+func categoriesHandler(packagesBasePath, cacheTime string) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		cacheHeaders(w, cacheTime)
 

--- a/config.yml
+++ b/config.yml
@@ -1,1 +1,1 @@
-packages.path: "./public/package"
+public_dir: "./public"

--- a/main_test.go
+++ b/main_test.go
@@ -23,7 +23,7 @@ var (
 
 func TestEndpoints(t *testing.T) {
 
-	packagesBasePath = "./testdata/package"
+	packagesBasePath := "./testdata/package"
 
 	tests := []struct {
 		endpoint string
@@ -32,13 +32,13 @@ func TestEndpoints(t *testing.T) {
 		handler  func(w http.ResponseWriter, r *http.Request)
 	}{
 		{"/", "", "info.json", catchAll("./testdata", testCacheTime)},
-		{"/search", "/search", "search.json", searchHandler(testCacheTime)},
-		{"/categories", "/categories", "categories.json", categoriesHandler(testCacheTime)},
-		{"/search?kibana=6.5.2", "/search", "search-kibana652.json", searchHandler(testCacheTime)},
-		{"/search?kibana=7.2.1", "/search", "search-kibana721.json", searchHandler(testCacheTime)},
-		{"/search?category=metrics", "/search", "search-category-metrics.json", searchHandler(testCacheTime)},
-		{"/search?category=logs", "/search", "search-category-logs.json", searchHandler(testCacheTime)},
-		{"/search?package=example", "/search", "search-package-example.json", searchHandler(testCacheTime)},
+		{"/search", "/search", "search.json", searchHandler(packagesBasePath, testCacheTime)},
+		{"/categories", "/categories", "categories.json", categoriesHandler(packagesBasePath, testCacheTime)},
+		{"/search?kibana=6.5.2", "/search", "search-kibana652.json", searchHandler(packagesBasePath, testCacheTime)},
+		{"/search?kibana=7.2.1", "/search", "search-kibana721.json", searchHandler(packagesBasePath, testCacheTime)},
+		{"/search?category=metrics", "/search", "search-category-metrics.json", searchHandler(packagesBasePath, testCacheTime)},
+		{"/search?category=logs", "/search", "search-category-logs.json", searchHandler(packagesBasePath, testCacheTime)},
+		{"/search?package=example", "/search", "search-package-example.json", searchHandler(packagesBasePath, testCacheTime)},
 		{"/package/example-1.0.0", "", "package.json", catchAll("./testdata", testCacheTime)},
 	}
 

--- a/search.go
+++ b/search.go
@@ -16,7 +16,7 @@ import (
 	"github.com/elastic/integrations-registry/util"
 )
 
-func searchHandler(cacheTime string) func(w http.ResponseWriter, r *http.Request) {
+func searchHandler(packagesBasePath, cacheTime string) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		cacheHeaders(w, cacheTime)
 


### PR DESCRIPTION
The only thing needed to start the server is having it pointed to the public directory to serve files from there. What the internal name is for the packages directory is an implementation detail.

Some refactoring of the code was needed for this change. Now path variables are passed to the handler instead of using a global variable. This also makes it simpler to test individually instead of modifying global variables.