### PR TITLE
Add base package

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The `/search` API endpoint has few additional query parameters. More might be ad
 * category: Filters the package by the given category. Available categories can be seend when going to `/categories` endpoint.
 * package: Filters by a specific package name, for example `mysql`. In contrast to the other endpoints, it will return
   by default all versions of this package.
+* internal: This can be set to true, to also list internal packages. This is set to `false` by default.
   
 The different query parameters above can be combined, so `?package=mysql&kibana=7.3.0` will return all mysql package versions
 which are compatible with `7.3.0`.

--- a/categories.go
+++ b/categories.go
@@ -33,6 +33,11 @@ func categoriesHandler(packagesBasePath, cacheTime string) func(w http.ResponseW
 		// Get unique list of newest packages
 		for _, p := range packages {
 
+			// Skip internal packages
+			if p.Internal {
+				continue
+			}
+
 			// Check if the version exists and if it should be added or not.
 			if pp, ok := packageList[p.Name]; ok {
 				// If the package in the list is newer, do nothing. Otherwise delete and later add the new one.

--- a/dev/package-examples/base-1.0.0/elasticsearch/ilm-policy/logs-default.json
+++ b/dev/package-examples/base-1.0.0/elasticsearch/ilm-policy/logs-default.json
@@ -1,0 +1,15 @@
+{
+        "policy": {
+            "phases": {
+                "hot": {
+                    "min_age": "0ms",
+                    "actions": {
+                        "rollover": {
+                            "max_size": "50gb",
+                            "max_age": "30d"
+                        }
+                    }
+                }
+            }
+        }
+}

--- a/dev/package-examples/base-1.0.0/elasticsearch/ilm-policy/metrics-default.json
+++ b/dev/package-examples/base-1.0.0/elasticsearch/ilm-policy/metrics-default.json
@@ -1,0 +1,17 @@
+{
+    "metrics-default": {
+        "policy": {
+            "phases": {
+                "hot": {
+                    "min_age": "0ms",
+                    "actions": {
+                        "rollover": {
+                            "max_size": "50gb",
+                            "max_age": "30d"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/dev/package-examples/base-1.0.0/manifest.yml
+++ b/dev/package-examples/base-1.0.0/manifest.yml
@@ -1,0 +1,25 @@
+name: base
+title: Base package
+description: >
+  The base package contains assets which are needed for the basic setup of the stack.
+
+  It contains the default ILM policies.
+version: 1.0.0
+categories: []
+release: ga
+
+# The user should not see this package and not be able to install it
+internal: true
+
+license: basic
+# This is called type integration because it is required for all the integration packages
+type: integration
+
+requirement:
+  elasticsearch:
+    # Requires ILM which was released in 6.6.
+    version.min: 6.6.0
+
+# No icons
+icons:
+

--- a/docs/api/search-package-internal.json
+++ b/docs/api/search-package-internal.json
@@ -1,0 +1,27 @@
+[
+  {
+    "description": "This is the example integration",
+    "download": "/package/example-1.0.0.tar.gz",
+    "name": "example",
+    "title": "Example Integration",
+    "type": "integration",
+    "version": "1.0.0"
+  },
+  {
+    "description": "This is the foo integration",
+    "download": "/package/foo-1.0.0.tar.gz",
+    "name": "foo",
+    "title": "Foo",
+    "type": "solution",
+    "version": "1.0.0"
+  },
+  {
+    "description": "Internal package",
+    "download": "/package/internal-1.2.0.tar.gz",
+    "internal": true,
+    "name": "internal",
+    "title": "Internal",
+    "type": "integration",
+    "version": "1.2.0"
+  }
+]

--- a/main_test.go
+++ b/main_test.go
@@ -39,6 +39,7 @@ func TestEndpoints(t *testing.T) {
 		{"/search?category=metrics", "/search", "search-category-metrics.json", searchHandler(packagesBasePath, testCacheTime)},
 		{"/search?category=logs", "/search", "search-category-logs.json", searchHandler(packagesBasePath, testCacheTime)},
 		{"/search?package=example", "/search", "search-package-example.json", searchHandler(packagesBasePath, testCacheTime)},
+		{"/search?internal=true", "/search", "search-package-internal.json", searchHandler(packagesBasePath, testCacheTime)},
 		{"/package/example-1.0.0", "", "package.json", catchAll("./testdata", testCacheTime)},
 	}
 

--- a/testdata/package/internal-1.2.0/index.json
+++ b/testdata/package/internal-1.2.0/index.json
@@ -1,0 +1,19 @@
+{
+  "name": "internal",
+  "title": "Internal",
+  "version": "1.2.0",
+  "description": "Internal package",
+  "type": "integration",
+  "categories": [],
+  "requirement": {
+    "kibana": {
+      "version.min": "",
+      "version.max": ""
+    }
+  },
+  "assets": [
+    "/package/internal-1.2.0/index.json",
+    "/package/internal-1.2.0/manifest.yml"
+  ],
+  "internal": true
+}

--- a/testdata/package/internal-1.2.0/manifest.yml
+++ b/testdata/package/internal-1.2.0/manifest.yml
@@ -1,0 +1,6 @@
+name: internal
+description: Internal package
+version: 1.2.0
+title: Internal
+categories: []
+internal: true

--- a/util/package.go
+++ b/util/package.go
@@ -36,6 +36,7 @@ type Package struct {
 	Screenshots   []Image     `yaml:"screenshots,omitempty" json:"screenshots,omitempty"`
 	Icons         []Image     `yaml:"icons,omitempty" json:"icons,omitempty"`
 	Assets        []string    `yaml:"assets,omitempty" json:"assets,omitempty"`
+	Internal      bool        `yaml:"internal,omitempty" json:"internal,omitempty"`
 }
 
 type Requirement struct {


### PR DESCRIPTION
The base package contains all the assets, which are used by all packages. This package is expected to be installed before any other package is installed. EPM should install it automatically and no user interaction should be needed.

For now this only contains the two default ILM policies for logs and metrics. More assets could be added later.

A flag `internal: true` was added to the packages so these packages should not be shown in the overview. By default the internal packages are not exposed in the `/search` endpoint. To also get internal packages, the query param `?internal=true` has to be set. In the `/categories` endpoint, internal packages are not counted.

Further changes:

* Test package for testing `internal: true` added
* README updated with new endpoint.
* Add test for `internal=true` query param