### PR TITLE
Update import syntax to match Handlebars

### DIFF
--- a/dev/package-examples/longdocs-1.0.4/docs/README.md
+++ b/dev/package-examples/longdocs-1.0.4/docs/README.md
@@ -16,7 +16,7 @@ This is a [link](https://github.com/elastic/integrations-registry) inside the do
 The following file shows how an event might look like:
 
 ```
-{{ > ./data.json }}
+{{> ./data.json }}
 ```
 
 ## Template parts


### PR DESCRIPTION
From https://github.com/wycats/handlebars.js#compatibility

>Handlebars does not allow space between the opening `{{` and a command character such as `#`, `/` or `>`. The command character must immediately follow the braces, so for example `{{> partial }}` is allowed but `{{ > partial }}` is not.