### PR TITLE
Fix test data generation

### DIFF
--- a/docs/api/package.json
+++ b/docs/api/package.json
@@ -3,6 +3,7 @@
   "title": "Example Integration",
   "version": "1.0.0",
   "description": "This is the example integration",
+  "type": "integration",
   "categories": [
     "logs",
     "metrics"

--- a/docs/api/search-kibana652.json
+++ b/docs/api/search-kibana652.json
@@ -1,9 +1,10 @@
 [
   {
     "description": "This is the example integration.",
-    "download": "/package/example-0.0.5.tar.gz",
+    "download": "/package/example-0.0.2.tar.gz",
     "name": "example",
+    "title": "Example",
     "type": "integration",
-    "version": "0.0.5"
+    "version": "0.0.2"
   }
 ]

--- a/docs/api/search-package-example.json
+++ b/docs/api/search-package-example.json
@@ -1,10 +1,11 @@
 [
   {
     "description": "This is the example integration.",
-    "download": "/package/example-0.0.5.tar.gz",
+    "download": "/package/example-0.0.2.tar.gz",
     "name": "example",
+    "title": "Example",
     "type": "integration",
-    "version": "0.0.5"
+    "version": "0.0.2"
   },
   {
     "description": "This is the example integration",

--- a/magefile.go
+++ b/magefile.go
@@ -74,6 +74,9 @@ func writeJsonFile(v interface{}, path string) error {
 func Check() error {
 	Format()
 
+	// Regenerates test data to make sure it stays the same
+	sh.RunV("go", "run", "./dev/generator/", "-sourceDir=testdata/package", "-publicDir=testdata", "-copy=false", "-tarGz=false")
+
 	sh.RunV("git", "update-index", "--refresh")
 	sh.RunV("git", "diff-index", "--exit-code", "HEAD", "--")
 

--- a/testdata/package/example-0.0.2/index.json
+++ b/testdata/package/example-0.0.2/index.json
@@ -1,7 +1,9 @@
 {
   "name": "example",
-  "version": "0.0.5",
+  "title": "Example",
+  "version": "0.0.2",
   "description": "This is the example integration.",
+  "type": "integration",
   "categories": [
     "logs"
   ],
@@ -23,6 +25,7 @@
     "/package/example-0.0.2/elasticsearch/ingest-pipeline/pipeline-tcp.json",
     "/package/example-0.0.2/kibana/dashboard/0c610510-5cbd-11e9-8477-077ec9664dbd.json",
     "/package/example-0.0.2/kibana/index-pattern/filebeat-*.json",
+    "/package/example-0.0.2/kibana/infrastructure-ui-source/default.json",
     "/package/example-0.0.2/kibana/visualization/0a994af0-5c9d-11e9-8477-077ec9664dbd.json",
     "/package/example-0.0.2/kibana/visualization/36f872a0-5c03-11e9-85b4-19d0072eb4f2.json",
     "/package/example-0.0.2/kibana/visualization/38f96190-5c99-11e9-8477-077ec9664dbd.json",

--- a/testdata/package/example-0.0.2/manifest.yml
+++ b/testdata/package/example-0.0.2/manifest.yml
@@ -1,6 +1,7 @@
 name: example
+title: Example
 description: This is the example integration.
-version: 0.0.5
+version: 0.0.2
 categories: ["logs"]
 
 requirement:

--- a/testdata/package/example-1.0.0/index.json
+++ b/testdata/package/example-1.0.0/index.json
@@ -3,6 +3,7 @@
   "title": "Example Integration",
   "version": "1.0.0",
   "description": "This is the example integration",
+  "type": "integration",
   "categories": [
     "logs",
     "metrics"

--- a/testdata/package/foo-1.0.0/index.json
+++ b/testdata/package/foo-1.0.0/index.json
@@ -3,6 +3,7 @@
   "title": "Foo",
   "version": "1.0.0",
   "description": "This is the foo integration",
+  "type": "solution",
   "categories": [
     "metrics"
   ],
@@ -13,6 +14,7 @@
     }
   },
   "assets": [
+    "/package/foo-1.0.0/index.json",
     "/package/foo-1.0.0/manifest.yml"
   ]
 }


### PR DESCRIPTION
When updating the generation process of assets, the test packages were not kept up to date. Some refactoring was needed to make it available again. Now it is always run as part of `mage check` so it is run on all tests. Like this, the test packages are also always up-to-date.

Some of the testdata had to be updated.